### PR TITLE
Add dashboard responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,7 +178,7 @@
           </section>
         </div>
 
-        <section class="card">
+        <section class="card" id="backlogCard">
           <div class="k">Backlog</div>
           <div class="row" style="margin-top:8px; align-items:center;">
             <div class="pill">Capacity <span id="capVal" class="mono">0/0</span></div>
@@ -221,7 +221,7 @@
           <pre class="small" id="reviewLog" style="margin-top:8px;">No reviews yet.</pre>
         </section>
 
-        <section class="card">
+        <section class="card" id="incidentsCard">
           <div class="k">Incidents</div>
           <pre class="small" id="eventLog">No incidents… yet.</pre>
         </section>
@@ -294,6 +294,22 @@
         </div>
 
       </aside>
+    </div>
+
+    <!-- Incident response: shown briefly when a new incident hits -->
+    <div id="incidentOverlay" class="incidentOverlay" hidden aria-live="polite" aria-atomic="true">
+      <div class="card incidentOverlayInner">
+        <div class="row" style="align-items:center;">
+          <div class="pill" style="border-color: color-mix(in oklab, var(--md-sys-color-error) 70%, transparent);">Incident</div>
+          <div id="incidentOverlayTitle" class="small mono" style="margin-left:10px; flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">—</div>
+          <button id="incidentOverlayDismiss" class="btn text" aria-label="Dismiss incident">✕</button>
+        </div>
+        <div id="incidentOverlayHint" class="small muted" style="margin-top:8px;">Respond fast: fix or defer the top ticket to stop the bleed.</div>
+        <div class="row" style="margin-top:10px; justify-content:flex-end;">
+          <button id="incidentOverlayBacklog" class="btn outlined">Open backlog</button>
+          <button id="incidentOverlayTriage" class="btn filled">Quick triage</button>
+        </div>
+      </div>
     </div>
 
     <script type="module" src="/src/main.ts"></script>

--- a/src/style.css
+++ b/src/style.css
@@ -62,7 +62,8 @@
   --glass-bg-2: rgba(20, 24, 32, 0.48);
   --glass-border: rgba(255,255,255,0.16);
   --glass-highlight: rgba(255,255,255,0.14);
-  --glass-shadow: 0 18px 60px rgba(0,0,0,0.42);
+  /* Softer by default to avoid looking clipped inside scroll containers. */
+  --glass-shadow: 0 14px 44px rgba(0,0,0,0.40);
   /* State layers */
   --md-state-hover: rgba(255,255,255,0.06);
   --md-state-press: var(--app-border);
@@ -210,15 +211,15 @@ body {
 /* Layout */
 .wrap {
   display: grid;
-  grid-template-columns: 1fr 372px;
+  /* Canvas + control surface. Side panel uses clamp so it can breathe on laptops
+     and become a real dashboard on wide monitors without crushing the canvas. */
+  grid-template-columns: minmax(420px, 1fr) minmax(340px, clamp(360px, 34vw, 760px));
   height: 100vh;
 }
 
 /* Give the side panel more room on large viewports so it can become a true “two-column” control surface */
 @media (min-width: 1400px) {
-  .wrap {
-    grid-template-columns: 1fr 520px;
-  }
+  .wrap { grid-template-columns: minmax(520px, 1fr) minmax(420px, clamp(520px, 32vw, 860px)); }
 }
 
 canvas {
@@ -242,6 +243,13 @@ canvas {
     linear-gradient(180deg,
       rgba(255,255,255,0.025) 0%,
       rgba(255,255,255,0.020) 100%);
+}
+
+/* On glass mode, big shadows + scroll containers can look "clipped".
+   Give the panel a tiny extra inset and slightly soften shadows. */
+html[data-glass="on"] .side {
+  padding-left: calc(var(--md-pad-3) + 2px);
+  padding-right: calc(var(--md-pad-3) + 2px);
 }
 
 .sideHeader {
@@ -502,13 +510,14 @@ ol { margin: 8px 0 0; }
 @media (max-width: 980px) {
   .wrap {
     grid-template-columns: 1fr;
-    grid-template-rows: 1fr 460px;
+    grid-template-rows: 1fr min(62vh, 540px);
   }
 
   .side {
     border-left: none;
     border-top: 1px solid var(--md-sys-color-outline-variant);
     box-shadow: var(--md-elevation-3);
+    border-radius: 20px 20px 0 0;
   }
 }
 
@@ -539,13 +548,53 @@ select:focus-visible {
 
 
 /* TicketFlow UI */
-.ticketList { display: flex; flex-direction: column; gap: 10px; }
-.ticket { display: flex; gap: 10px; padding: 10px; border-radius: 14px; background: var(--md-sys-color-surface-container); border: 1px solid rgba(255,255,255,0.06); }
+.ticketList {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+}
+
+@media (min-width: 720px) {
+  /* When the side panel is wide enough, show tickets in 2 columns. */
+  .ticketList { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+.ticket {
+  display: flex;
+  gap: 10px;
+  padding: 10px;
+  border-radius: 14px;
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid rgba(255,255,255,0.06);
+}
+
 .ticketMain { flex: 1; min-width: 0; }
-.ticketTitle { font-size: 13px; font-weight: 650; color: var(--md-sys-color-on-surface); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+.ticketTitle {
+  font-size: 13px;
+  font-weight: 650;
+  color: var(--md-sys-color-on-surface);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
 .ticketMeta { font-size: 11px; color: rgba(255,255,255,0.72); margin-top: 3px; }
-.ticketBtns { display: flex; gap: 8px; align-items: center; }
+.ticketBtns {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
 .btn.is-disabled { opacity: 0.55; pointer-events: none; }
+
+/* Stack ticket actions under content on narrow panels (mobile bottom sheet) */
+@media (max-width: 520px) {
+  .ticket { flex-direction: column; }
+  .ticketBtns { justify-content: flex-start; }
+}
 
 
 /* RegMatrix UI */
@@ -730,7 +779,6 @@ html[data-glass="on"] .ticket::after {
   opacity: 0.55;
 }
 
-html[data-glass="on"] .card,
 html[data-glass="on"] .ticket {
   position: relative;
   overflow: hidden;
@@ -785,7 +833,58 @@ html[data-glass="on"] .ticket {
 }
 
 .ticketRefactors select {
-  max-width: 360px;
+  max-width: min(360px, 100%);
+}
+
+/* A tiny native accordion for refactor-heavy tickets */
+.ticketMore {
+  margin-top: 8px;
+}
+.ticketMore summary {
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+}
+.ticketMore summary::-webkit-details-marker { display: none; }
+.ticketMoreSummary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  padding: 6px 10px;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  background: var(--md-state-hover);
+  font-size: 12px;
+}
+
+/* Incident highlighting */
+html.incident-hot #incidentsCard,
+html.incident-hot #backlogCard {
+  border-color: color-mix(in oklab, var(--md-sys-color-error) 55%, var(--md-sys-color-outline-variant));
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--md-sys-color-error) 35%, transparent);
+}
+
+.incidentOverlay {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 9999;
+  width: min(440px, calc(100vw - 32px));
+  pointer-events: none;
+}
+
+.incidentOverlayInner {
+  pointer-events: auto;
+  border-color: color-mix(in oklab, var(--md-sys-color-error) 55%, var(--md-sys-color-outline-variant));
+}
+
+@media (max-width: 980px) {
+  .incidentOverlay {
+    left: 12px;
+    right: 12px;
+    bottom: calc(min(62vh, 540px) + 12px);
+    width: auto;
+  }
 }
 
 


### PR DESCRIPTION
Tickets: #8 #10 #11 

1. Wider desktop dashboard: side panel now uses clamp() sizing so it can expand on normal browsers without crushing the canvas.
Mobile-friendly bottom sheet: on narrow screens the side panel becomes a bottom sheet with a sane height (min(62vh, 540px)).

2. Backlog redesign to “fit”:
-Tickets are now a grid when the panel is wide enough (2 columns).
-Ticket actions wrap instead of overflowing.

3. Heavy “architecture refactor” controls moved into a <details> expandable block per ticket.

4. Removed the glass-mode overflow, hidden behavior from cards (kept it only for tickets) and softened the shadow to avoid “clipped” visuals in scroll containers.

5. QoL improvement: when a new incident hits, the UI highlights Backlog + Incidents and shows a small overlay.