### PR TITLE
Add dashboard tamper protection v1

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,6 +310,7 @@
         <section class="card">
           <div class="row" style="align-items:center;">
             <div class="k" data-i18n="card.scoreboard">Scoreboard (local)</div>
+            <span id="integrityBadge" class="pill" hidden style="margin-left:8px; font-size:11px; border-color:rgba(255,82,82,.5); color:rgba(255,82,82,.95);">⚠ Tampered</span>
             <div style="margin-left:auto;">
               <button id="btnClearScoreboard" class="btn text" data-i18n="btn.clear">Clear</button>
             </div>

--- a/src/integrity.ts
+++ b/src/integrity.ts
@@ -1,0 +1,130 @@
+const APP_SALT = 'asr:integrity:v1';
+const VERSION_KEY = 'asr:integrity:version';
+const CURRENT_VERSION = '1';
+
+// ---------------------------------------------------------------------------
+// Tamper flag (module-level singleton, sticky for session)
+// ---------------------------------------------------------------------------
+
+let tampered = false;
+let tamperReason: string | null = null;
+const listeners: Array<() => void> = [];
+
+export function markTampered(reason: string): void {
+  if (tampered) return;
+  tampered = true;
+  tamperReason = reason;
+  for (const cb of listeners) cb();
+}
+
+export function getTamperState(): { tampered: boolean; reason: string | null } {
+  return { tampered, reason: tamperReason };
+}
+
+export function onTamperDetected(cb: () => void): void {
+  listeners.push(cb);
+}
+
+/** Reset tamper state — only for tests. */
+export function _resetForTest(): void {
+  tampered = false;
+  tamperReason = null;
+  listeners.length = 0;
+}
+
+// ---------------------------------------------------------------------------
+// HMAC key derivation (Web Crypto)
+// ---------------------------------------------------------------------------
+
+export async function deriveKey(buildSha: string): Promise<CryptoKey> {
+  const raw = new TextEncoder().encode(APP_SALT + ':' + buildSha);
+  return crypto.subtle.importKey('raw', raw, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+}
+
+// ---------------------------------------------------------------------------
+// HMAC sign / verify
+// ---------------------------------------------------------------------------
+
+function bufToHex(buf: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buf))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function signPayload(key: CryptoKey, data: string): Promise<string> {
+  const encoded = new TextEncoder().encode(data);
+  const sig = await crypto.subtle.sign('HMAC', key, encoded);
+  return bufToHex(sig);
+}
+
+export async function verifyPayload(key: CryptoKey, data: string, sig: string): Promise<boolean> {
+  const expected = await signPayload(key, data);
+  if (expected.length !== sig.length) return false;
+  // Constant-time-ish comparison (not security-critical, but good practice)
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) {
+    diff |= expected.charCodeAt(i) ^ sig.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+// ---------------------------------------------------------------------------
+// localStorage signature helpers
+// ---------------------------------------------------------------------------
+
+export async function sealStorageKey(lsKey: string, key: CryptoKey): Promise<void> {
+  try {
+    const raw = localStorage.getItem(lsKey);
+    if (raw === null) return;
+    const sig = await signPayload(key, raw);
+    localStorage.setItem(lsKey + ':sig', sig);
+  } catch {
+    // private browsing / quota — ignore
+  }
+}
+
+/**
+ * Verify a localStorage key against its companion :sig key.
+ * Returns `true` (valid), `false` (tampered), or `null` (no data).
+ */
+export async function verifyStorageKey(lsKey: string, key: CryptoKey): Promise<boolean | null> {
+  try {
+    const raw = localStorage.getItem(lsKey);
+    if (raw === null) return null;
+    const sig = localStorage.getItem(lsKey + ':sig');
+    if (sig === null) return false; // data exists but no signature
+    return verifyPayload(key, raw, sig);
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Score sanity check
+// ---------------------------------------------------------------------------
+
+/** Max per-tick score is 12. Allow 25% tolerance for floating-point drift. */
+export function isScoreSane(finalScore: number, durationSec: number, multiplier: number): boolean {
+  const maxPossible = 12 * durationSec * multiplier * 1.25;
+  return finalScore <= maxPossible;
+}
+
+// ---------------------------------------------------------------------------
+// Migration: first load with integrity — seal existing data, don't flag
+// ---------------------------------------------------------------------------
+
+export function needsMigration(): boolean {
+  try {
+    return localStorage.getItem(VERSION_KEY) !== CURRENT_VERSION;
+  } catch {
+    return false;
+  }
+}
+
+export function setMigrationDone(): void {
+  try {
+    localStorage.setItem(VERSION_KEY, CURRENT_VERSION);
+  } catch {
+    // ignore
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
 import './style.css';
 import { GameSim } from './sim';
 import { AchievementsTracker, LocalStorageAchStorage, AchEvent, AchievementUnlock } from './achievements';
-import { addScoreEntry, clearScoreboard, loadScoreboard } from './scoreboard';
+import { addScoreEntry, clearScoreboard, loadScoreboard, sealScoreboard, verifyScoreboard } from './scoreboard';
 import { MODE, Mode, ComponentType, Ticket, EvalPreset, EVAL_PRESET, RefactorAction } from './types';
+import { deriveKey, sealStorageKey, verifyStorageKey, markTampered, getTamperState, isScoreSane, needsMigration, setMigrationDone } from './integrity';
 import { applyTranslations, getLanguage, loadLanguage, populateLanguageSelect, setLanguage, t, type Lang } from './i18n';
 
 type ThemeMode = 'system' | 'light' | 'dark';
@@ -183,6 +184,9 @@ type UIRefs = {
   refactorTicketTitle: HTMLElement;
   refactorTargetSelect: HTMLSelectElement;
   refactorOptions: HTMLElement;
+
+  // Integrity
+  integrityBadge: HTMLElement;
 };
 
 
@@ -211,6 +215,31 @@ const shortSha = sha === 'dev' ? 'dev' : sha.slice(0, 7);
 refs.buildInfo.textContent = t('build.info', { sha: shortSha, base: String(import.meta.env.BASE_URL) });
 
 let lastSavedRunId: string | null = null;
+
+// --- Integrity (tamper protection v1) -------------------------------------
+const ACH_PREFIX = 'survival.achievements.';
+const integrityKeyPromise = deriveKey(sha);
+
+integrityKeyPromise.then(async (key) => {
+  if (needsMigration()) {
+    // First load with integrity — seal existing data silently.
+    await sealScoreboard(key);
+    for (const p of Object.values(EVAL_PRESET)) {
+      await sealStorageKey(ACH_PREFIX + p, key);
+    }
+    setMigrationDone();
+  } else {
+    const sbOk = await verifyScoreboard(key);
+    if (sbOk === false) markTampered('scoreboard');
+    for (const p of Object.values(EVAL_PRESET)) {
+      const achOk = await verifyStorageKey(ACH_PREFIX + p, key);
+      if (achOk === false) markTampered('achievements');
+    }
+  }
+});
+
+// Paused-state snapshot for runtime tamper detection.
+let pausedSnapshot: { budget: number; score: number; rating: number } | null = null;
 
 // Achievements are stored per preset.
 const ach = new AchievementsTracker(EVAL_PRESET.SENIOR, new LocalStorageAchStorage());
@@ -886,6 +915,7 @@ refs.btnStart.onclick = () => {
   if (ach.getPreset() !== preset) ach.setPreset(preset);
   achLastTickSec = -1;
   applyAchievementRewards(ach.onEvents([{ type: 'RUN_START', atSec: sim.timeSec, budget: sim.budget, architectureDebt: sim.architectureDebt }]));
+  integrityKeyPromise.then(key => sealStorageKey(ACH_PREFIX + preset, key));
   sim.running = true;
   startTickLoop();
   syncUI();
@@ -897,6 +927,7 @@ refs.btnPause.onclick = () => {
 refs.btnReset.onclick = () => {
   // Treat reset as run end for achievements tracking.
   applyAchievementRewards(ach.onEvents([{ type: 'RUN_END', atSec: sim.timeSec, reason: 'RESET' }]));
+  integrityKeyPromise.then(key => sealStorageKey(ACH_PREFIX + (refs.presetSelect.value as EvalPreset), key));
   sim.running = false;
   achLastTickSec = -1;
   const seedStr = (refs.seedInput.value ?? '').trim();
@@ -1041,6 +1072,7 @@ refs.btnCopyRun.onclick = async () => {
 
 refs.btnClearScoreboard.onclick = () => {
   clearScoreboard();
+  integrityKeyPromise.then(key => sealScoreboard(key));
   renderScoreboard();
   toast(t('toast.scoreboardCleared'));
 };
@@ -1387,6 +1419,7 @@ function syncUI() {
   if (achEvents.length) {
     const unlocked = ach.onEvents(achEvents);
     applyAchievementRewards(unlocked);
+    integrityKeyPromise.then(key => sealStorageKey(ACH_PREFIX + currentPreset, key));
   }
 
   renderAchievementSummary(currentPreset);
@@ -1462,6 +1495,9 @@ function syncUI() {
 
     if (s.lastRun.runId && s.lastRun.runId !== lastSavedRunId) {
       lastSavedRunId = s.lastRun.runId;
+      if (!isScoreSane(s.lastRun.finalScore, s.lastRun.durationSec, s.lastRun.multiplier)) {
+        markTampered('score');
+      }
       addScoreEntry({
         runId: s.lastRun.runId,
         seed: s.lastRun.seed,
@@ -1474,6 +1510,7 @@ function syncUI() {
         architectureDebt: s.lastRun.architectureDebt,
         rating: s.lastRun.rating,
       });
+      integrityKeyPromise.then(key => sealScoreboard(key));
       renderScoreboard();
     }
   } else {
@@ -1509,6 +1546,21 @@ function syncUI() {
   // ZeroDayPulse
   const adv = sim.getAdvisories().filter(a => !a.mitigated).slice(0, 1);
   setText(refs.advisoryText, adv.length ? t('advisory.active', { title: adv[0].title }) : '');
+
+  // --- Integrity: paused-state tamper check --------------------------------
+  if (!sim.running && sim.timeSec > 0) {
+    if (pausedSnapshot) {
+      if (sim.budget !== pausedSnapshot.budget ||
+          sim.score !== pausedSnapshot.score ||
+          sim.rating !== pausedSnapshot.rating) {
+        markTampered('runtime');
+      }
+    }
+    pausedSnapshot = { budget: sim.budget, score: sim.score, rating: sim.rating };
+  } else {
+    pausedSnapshot = null;
+  }
+  refs.integrityBadge.hidden = !getTamperState().tampered;
 
   renderTickets();
   renderRegions();
@@ -1647,7 +1699,9 @@ function bindUI(): UIRefs {
     btnCloseRefactor: must<HTMLButtonElement>('btnCloseRefactor'),
     refactorTicketTitle: must('refactorTicketTitle'),
     refactorTargetSelect: must<HTMLSelectElement>('refactorTargetSelect'),
-    refactorOptions: must('refactorOptions')
+    refactorOptions: must('refactorOptions'),
+
+    integrityBadge: must('integrityBadge'),
   };
 }
 

--- a/src/scoreboard.ts
+++ b/src/scoreboard.ts
@@ -1,4 +1,5 @@
 import type { ScoreEntry } from './types';
+import { sealStorageKey, verifyStorageKey } from './integrity';
 
 const KEY = 'asr:scoreboard:v1';
 const MAX = 20;
@@ -37,7 +38,16 @@ export function addScoreEntry(entry: ScoreEntry): ScoreEntry[] {
 export function clearScoreboard(): void {
   try {
     localStorage.removeItem(KEY);
+    localStorage.removeItem(KEY + ':sig');
   } catch {
     // ignore
   }
+}
+
+export async function sealScoreboard(key: CryptoKey): Promise<void> {
+  return sealStorageKey(KEY, key);
+}
+
+export async function verifyScoreboard(key: CryptoKey): Promise<boolean | null> {
+  return verifyStorageKey(KEY, key);
 }

--- a/tests/unit/integrity.test.ts
+++ b/tests/unit/integrity.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  deriveKey,
+  signPayload,
+  verifyPayload,
+  markTampered,
+  getTamperState,
+  onTamperDetected,
+  isScoreSane,
+  _resetForTest,
+} from '../../src/integrity';
+
+beforeEach(() => {
+  _resetForTest();
+});
+
+describe('HMAC sign / verify', () => {
+  it('round-trips: sign then verify returns true', async () => {
+    const key = await deriveKey('test-sha');
+    const data = '{"score":42}';
+    const sig = await signPayload(key, data);
+    expect(await verifyPayload(key, data, sig)).toBe(true);
+  });
+
+  it('rejects modified data', async () => {
+    const key = await deriveKey('test-sha');
+    const sig = await signPayload(key, '{"score":42}');
+    expect(await verifyPayload(key, '{"score":99}', sig)).toBe(false);
+  });
+
+  it('rejects wrong signature', async () => {
+    const key = await deriveKey('test-sha');
+    expect(await verifyPayload(key, '{"score":42}', 'deadbeef')).toBe(false);
+  });
+});
+
+describe('deriveKey', () => {
+  it('produces a CryptoKey', async () => {
+    const key = await deriveKey('abc123');
+    expect(key).toBeDefined();
+    expect(key.algorithm).toMatchObject({ name: 'HMAC' });
+  });
+
+  it('different SHAs produce different signatures', async () => {
+    const keyA = await deriveKey('sha-A');
+    const keyB = await deriveKey('sha-B');
+    const data = 'same-data';
+    const sigA = await signPayload(keyA, data);
+    const sigB = await signPayload(keyB, data);
+    expect(sigA).not.toBe(sigB);
+  });
+});
+
+describe('tamper flag', () => {
+  it('starts untampered', () => {
+    expect(getTamperState().tampered).toBe(false);
+    expect(getTamperState().reason).toBeNull();
+  });
+
+  it('markTampered sets flag and reason', () => {
+    markTampered('scoreboard');
+    expect(getTamperState().tampered).toBe(true);
+    expect(getTamperState().reason).toBe('scoreboard');
+  });
+
+  it('flag is sticky — second call does not override reason', () => {
+    markTampered('scoreboard');
+    markTampered('runtime');
+    expect(getTamperState().reason).toBe('scoreboard');
+  });
+
+  it('onTamperDetected callback fires', () => {
+    let called = false;
+    onTamperDetected(() => { called = true; });
+    markTampered('test');
+    expect(called).toBe(true);
+  });
+});
+
+describe('isScoreSane', () => {
+  it('accepts legitimate scores', () => {
+    // 300 seconds * 12 max/tick * 1.0 multiplier = 3600 max
+    expect(isScoreSane(2000, 300, 1.0)).toBe(true);
+  });
+
+  it('accepts scores near the limit', () => {
+    // 100s * 12 * 1.12 * 1.25 = 1680
+    expect(isScoreSane(1680, 100, 1.12)).toBe(true);
+  });
+
+  it('rejects impossible scores', () => {
+    // 60 seconds * 12 * 1.0 * 1.25 = 900 max
+    expect(isScoreSane(50000, 60, 1.0)).toBe(false);
+  });
+
+  it('rejects score of 10000 in 10 seconds', () => {
+    // 10 * 12 * 1.0 * 1.25 = 150 max
+    expect(isScoreSane(10000, 10, 1.0)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #24.

Adds client-side tamper detection for the game dashboard with three layers of protection:

- **Storage HMAC signatures**: scoreboard and achievement localStorage entries are signed with HMAC-SHA-256 (Web Crypto API). Key derived from build commit SHA + app salt. Tampered entries are flagged on page load.
- **Runtime paused-state check**: snapshots budget/score/rating while the sim is paused. If values change without the sim running (e.g. console edits), flags tampering.
- **Score sanity check**: verifies final score does not exceed the theoretical maximum (12 pts/tick * duration * multiplier * 1.25 tolerance) at run end.

A red "Tampered" badge appears next to the scoreboard header when any check fails. The flag is sticky for the session.

Includes graceful migration: existing users upgrading to this version get their current data auto-sealed rather than false-flagged.

### Files changed
- `src/integrity.ts` (new): HMAC sign/verify, tamper flag, score sanity, migration
- `src/scoreboard.ts`: seal/verify wrappers, clear companion sig on clear
- `src/main.ts`: async key init, storage verification, paused-state check, badge in syncUI
- `index.html`: integrityBadge element

## Test plan

- [x] `npm run build` - clean compile (12 modules)
- [x] `npm run test:unit` - 20/20 pass (13 new integrity tests)
- [x] `npm run test:dom` - 109 DOM IDs validated (+1 integrityBadge)
- [x] `npm run test:e2e:ci` - E2E smoke passes
- [x] CI checks pass
- [ ] Manual: edit `asr:scoreboard:v1` in DevTools, reload, badge appears
- [ ] Manual: pause game, run `sim.budget = 99999` in console, badge appears