### PR TITLE
Use user-input entropy for default seed generation

### DIFF
--- a/src/entropy.ts
+++ b/src/entropy.ts
@@ -1,0 +1,78 @@
+/**
+ * Passive entropy collector for seed generation.
+ *
+ * Gathers timing and positional data from user interactions (mouse, keyboard,
+ * touch) and mixes them into a 32-bit hash. Used as a higher-quality default
+ * seed when the user does not provide one manually.
+ */
+
+const TARGET_SAMPLES = 64;
+
+class EntropyPool {
+  private hash = 0x811c9dc5; // FNV offset basis
+  private samples = 0;
+  private listening = false;
+
+  constructor() {
+    if (typeof window !== 'undefined') this.startListening();
+  }
+
+  private mix(value: number): void {
+    // FNV-1a-inspired mixing: XOR then multiply.
+    this.hash ^= value & 0xff;
+    this.hash = Math.imul(this.hash, 0x01000193) >>> 0;
+    this.hash ^= (value >>> 8) & 0xff;
+    this.hash = Math.imul(this.hash, 0x01000193) >>> 0;
+    this.samples++;
+    if (this.samples >= TARGET_SAMPLES) this.stopListening();
+  }
+
+  private onMouse = (e: MouseEvent): void => {
+    this.mix(e.clientX ^ (e.clientY << 16));
+    this.mix(e.timeStamp * 1000);
+  };
+
+  private onKey = (e: KeyboardEvent): void => {
+    this.mix(e.keyCode ^ (e.timeStamp * 1000));
+  };
+
+  private onPointer = (e: PointerEvent): void => {
+    this.mix(e.clientX ^ (e.clientY << 16));
+    this.mix(e.timeStamp * 1000);
+  };
+
+  private startListening(): void {
+    if (this.listening) return;
+    this.listening = true;
+    window.addEventListener('mousemove', this.onMouse, { passive: true });
+    window.addEventListener('keydown', this.onKey, { passive: true });
+    window.addEventListener('pointerdown', this.onPointer, { passive: true });
+  }
+
+  private stopListening(): void {
+    if (!this.listening) return;
+    this.listening = false;
+    window.removeEventListener('mousemove', this.onMouse);
+    window.removeEventListener('keydown', this.onKey);
+    window.removeEventListener('pointerdown', this.onPointer);
+  }
+
+  /** Feed arbitrary numeric data into the pool (useful for testing). */
+  feed(value: number): void {
+    this.mix(value);
+  }
+
+  /** Derive a uint32 seed from the collected entropy. Falls back to Date.now() if no events were collected. */
+  seed(): number {
+    if (this.samples === 0) {
+      return (Date.now() & 0xffffffff) >>> 0;
+    }
+    // Final avalanche: mix in current time for extra uniqueness per call.
+    let h = this.hash ^ ((Date.now() & 0xffff) * 0x9e3779b9);
+    h = Math.imul(h ^ (h >>> 16), 0x45d9f3b) >>> 0;
+    h = Math.imul(h ^ (h >>> 13), 0x45d9f3b) >>> 0;
+    return (h ^ (h >>> 16)) >>> 0;
+  }
+}
+
+export const entropyPool = new EntropyPool();

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { AchievementsTracker, LocalStorageAchStorage, AchEvent, AchievementUnloc
 import { addScoreEntry, clearScoreboard, loadScoreboard, sealScoreboard, verifyScoreboard } from './scoreboard';
 import { MODE, Mode, ComponentType, Ticket, EvalPreset, EVAL_PRESET, RefactorAction } from './types';
 import { deriveKey, sealStorageKey, verifyStorageKey, markTampered, getTamperState, isScoreSane, needsMigration, setMigrationDone } from './integrity';
+import './entropy';
 import { applyTranslations, getLanguage, loadLanguage, populateLanguageSelect, setLanguage, t, type Lang } from './i18n';
 
 type ThemeMode = 'system' | 'light' | 'dark';

--- a/src/sim.ts
+++ b/src/sim.ts
@@ -20,6 +20,7 @@ const COMPONENT_DEPS: Record<string, Array<'net' | 'image' | 'json' | 'auth' | '
 
 import { ACTION_KEYS, ActionDef, ActionKey, Link, MODE, Mode, Component, ComponentDef, ComponentType, Request, Ticket, TicketKind, TicketSeverity, Advisory, PlatformState, RegionState, RegionCode, EvalPreset, EVAL_PRESET, RunResult, EndReason, RefactorOption, RefactorAction, ArchViolation, RefactorRoadmapStep } from './types';
 import { Rng } from './rng';
+import { entropyPool } from './entropy';
 
 export const ComponentDefs: Record<ComponentType, ComponentDef> = {
   // Core layers (Android mental model, not backend microservices)
@@ -224,7 +225,7 @@ export class GameSim {
     this.eventStream.push({ type: 'RUN_RESET', atSec: 0 });
 
     // Deterministic seed: same seed => same run.
-    const s = (opts?.seed ?? (Date.now() & 0xffffffff)) >>> 0;
+    const s = (opts?.seed ?? entropyPool.seed()) >>> 0;
     this.seed = s;
     this.rng = new Rng(s);
     this.score = 0;

--- a/tests/unit/entropy.test.ts
+++ b/tests/unit/entropy.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { entropyPool } from '../../src/entropy';
+
+describe('entropyPool', () => {
+  it('seed() returns a uint32 number', () => {
+    const s = entropyPool.seed();
+    expect(typeof s).toBe('number');
+    expect(s).toBeGreaterThanOrEqual(0);
+    expect(s).toBeLessThanOrEqual(0xffffffff);
+    expect(Number.isInteger(s)).toBe(true);
+  });
+
+  it('feeding different data produces different seeds', () => {
+    entropyPool.feed(111);
+    const s1 = entropyPool.seed();
+    entropyPool.feed(999);
+    const s2 = entropyPool.seed();
+    expect(s1).not.toBe(s2);
+  });
+
+  it('seed() returns non-zero values', () => {
+    entropyPool.feed(42);
+    const s = entropyPool.seed();
+    expect(s).not.toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #16.

When the user starts a game without providing a seed, the default seed is now derived from collected user-input entropy (mouse movements, key presses, pointer events) instead of `Date.now()`. This produces higher-quality randomness for seed generation.

**How it works:**
- A passive `EntropyPool` collector listens to mousemove, keydown, and pointerdown events on page load
- Event timestamps and coordinates are mixed into a running 32-bit hash (FNV-1a-inspired)
- After 64 samples are collected, listeners are automatically removed
- When a seed is needed, the pool produces a uint32 with a final avalanche step mixed with current time

**What is unchanged:**
- Manual seeds typed by the user are used as-is
- Daily seed button still uses UTC date
- Game remains fully deterministic and replayable per seed
- E2E tests use fixed seed 12345 (unaffected)

### Files changed
- `src/entropy.ts` (new): passive entropy collector (~80 lines)
- `src/sim.ts`: replaced `Date.now()` fallback with `entropyPool.seed()`
- `src/main.ts`: explicit import to start collection early

## Test plan

- [x] `npm run build` - clean compile (13 modules)
- [x] `npm run test:unit` - 23/23 pass (3 new entropy tests)
- [x] `npm run test:e2e:ci` - E2E smoke passes
- [x] CI checks pass