### PR TITLE
Add asymmetric win conditions and scoring bonuses

### DIFF
--- a/src/sim.ts
+++ b/src/sim.ts
@@ -18,7 +18,7 @@ const COMPONENT_DEPS: Record<string, Array<'net' | 'image' | 'json' | 'auth' | '
   A11Y: [],
 };
 
-import { ACTION_KEYS, ActionDef, ActionKey, Link, MODE, Mode, Component, ComponentDef, ComponentType, Request, Ticket, TicketKind, TicketSeverity, Advisory, PlatformState, RegionState, RegionCode, EvalPreset, EVAL_PRESET, RunResult, EndReason, RefactorOption, RefactorAction, ArchViolation, RefactorRoadmapStep } from './types';
+import { ACTION_KEYS, ActionDef, ActionKey, Link, MODE, Mode, Component, ComponentDef, ComponentType, Request, Ticket, TicketKind, TicketSeverity, Advisory, PlatformState, RegionState, RegionCode, EvalPreset, EVAL_PRESET, RunResult, EndReason, ScoreBonus, RefactorOption, RefactorAction, ArchViolation, RefactorRoadmapStep } from './types';
 import { Rng } from './rng';
 import { entropyPool } from './entropy';
 
@@ -210,6 +210,7 @@ export class GameSim {
   traffic = 0;
 
   private lastEventAt = 0;
+  private incidentCount = 0;
   private eventLines: string[] = [];
   private eventStream: SimEvent[] = [];
 
@@ -314,6 +315,7 @@ export class GameSim {
     this.traffic = 0;
 
     this.lastEventAt = 0;
+    this.incidentCount = 0;
     this.eventLines = [];
 
     this.queues.clear();
@@ -1586,6 +1588,7 @@ private tickCoverageGate() {
     this.eventLines.unshift(`${tag}  ${msg}`);
     if (this.eventLines.length > 18) this.eventLines.length = 18;
     this.lastEventAt = this.timeSec;
+    if (category === 'INCIDENT') this.incidentCount++;
     // On-call adrenaline: a brief capacity regen burst when incidents hit.
     this.engAdrenalineUntil = this.timeSec + 22;
 
@@ -2200,12 +2203,53 @@ private tickCoverageGate() {
     return 1.0;
   }
 
+  private evaluateBonuses(reason: EndReason): ScoreBonus[] {
+    const bonuses: ScoreBonus[] = [];
+    if (reason !== 'SHIFT_COMPLETE') return bonuses;
+
+    // Preset-specific bonus objectives
+    if (this.preset === EVAL_PRESET.JUNIOR_MID) {
+      bonuses.push({ id: 'survived', label: 'Survived the shift', pct: 0.15 });
+    }
+    if (this.preset === EVAL_PRESET.SENIOR && this.engRefillsUsed === 0) {
+      bonuses.push({ id: 'no_refills', label: 'Zero refills used', pct: 0.20 });
+    }
+    if (this.preset === EVAL_PRESET.STAFF && Math.round(this.architectureDebt) === 0) {
+      bonuses.push({ id: 'zero_debt', label: 'Zero architecture debt', pct: 0.25 });
+    }
+    if (this.preset === EVAL_PRESET.PRINCIPAL && this.incidentCount === 0 && this.rating >= 4.8) {
+      bonuses.push({ id: 'flawless', label: 'Flawless (zero incidents, rating >= 4.8)', pct: 0.30 });
+    }
+
+    // Universal bonuses (any preset, SHIFT_COMPLETE only)
+    if (this.tickets.length === 0) {
+      bonuses.push({ id: 'clean_desk', label: 'Clean desk (zero open tickets)', pct: 0.10 });
+    }
+    if (this.rating >= 4.8) {
+      bonuses.push({ id: 'high_rating', label: 'High rating (>= 4.8)', pct: 0.10 });
+    }
+
+    return bonuses;
+  }
+
+  private endRunMultiplier(reason: EndReason): number {
+    if (reason === 'BUDGET_DEPLETED') return 0.70;
+    if (reason === 'RATING_COLLAPSED') return 0.50;
+    return 1.0;
+  }
+
   private endRun(reason: EndReason, failureRate: number, anrRisk: number, p95: number) {
     this.running = false;
     this.eventStream.push({ type: 'RUN_END', atSec: this.timeSec, reason });
-    const mult = this.scoreMultiplier();
+
+    const baseMult = this.scoreMultiplier();
+    const endMult = this.endRunMultiplier(reason);
+    const bonuses = this.evaluateBonuses(reason);
+    const bonusMult = 1 + bonuses.reduce((sum, b) => sum + b.pct, 0);
+    const totalMult = baseMult * endMult * bonusMult;
+
     const raw = Math.max(0, this.score);
-    const finalScore = Math.round(raw * mult);
+    const finalScore = Math.round(raw * totalMult);
     const runId = `${this.seed}-${Date.now()}`;
 
     const summary: string[] = [
@@ -2213,12 +2257,20 @@ private tickCoverageGate() {
       `Preset: ${this.preset}`,
       `Seed: ${this.seed}`,
       `Duration: ${Math.floor(this.timeSec)}s`,
-      `Final score: ${finalScore} (x${mult.toFixed(2)})`,
+      `Final score: ${finalScore} (x${totalMult.toFixed(2)})`,
       `Rating: ${this.rating.toFixed(1)}★ • Budget: $${Math.round(this.budget)}`,
       `Failure: ${(failureRate * 100).toFixed(1)}% • ANR: ${(anrRisk * 100).toFixed(1)}% • P95: ${Math.round(p95)}ms`,
       `Jank: ${Math.round(this.jankPct)}% • Heap: ${Math.round(this.heapMb)}MB`,
       `Architecture debt: ${Math.round(this.architectureDebt)}/100 • Tickets open: ${this.tickets.length}`,
     ];
+
+    if (reason !== 'SHIFT_COMPLETE') {
+      summary.push(`Failure penalty: x${endMult.toFixed(2)}`);
+    }
+    if (bonuses.length) {
+      summary.push('Bonuses:');
+      for (const b of bonuses) summary.push(`  +${Math.round(b.pct * 100)}% ${b.label}`);
+    }
 
     const top = this.tickets
       .slice()
@@ -2238,7 +2290,8 @@ private tickCoverageGate() {
       durationSec: Math.floor(this.timeSec),
       rawScore: Math.round(raw),
       finalScore,
-      multiplier: mult,
+      multiplier: totalMult,
+      bonuses,
       rating: this.rating,
       budget: this.budget,
       failureRate,

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,6 +209,12 @@ export type EndReason =
   | 'RATING_COLLAPSED'
   | 'SHIFT_COMPLETE';
 
+export type ScoreBonus = {
+  id: string;
+  label: string;
+  pct: number; // e.g. 0.15 = +15%
+};
+
 export type RunResult = {
   runId: string;
   seed: number;
@@ -220,6 +226,7 @@ export type RunResult = {
   rawScore: number;
   finalScore: number;
   multiplier: number;
+  bonuses: ScoreBonus[];
 
   // End-of-run snapshot
   rating: number;

--- a/tests/unit/scoring.test.ts
+++ b/tests/unit/scoring.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { GameSim } from '../../src/sim';
+
+describe('asymmetric scoring', () => {
+  function makeSim(): any {
+    return new GameSim();
+  }
+
+  describe('failure penalties', () => {
+    it('BUDGET_DEPLETED applies 0.70x penalty', () => {
+      const sim = makeSim();
+      sim.reset({ width: 800, height: 600 }, { seed: 1 });
+      sim.running = true;
+      // Simulate some ticks to accumulate score
+      for (let i = 0; i < 30; i++) sim.tick();
+      // Force budget depletion
+      sim.budget = -1;
+      sim.tick();
+      expect(sim.lastRun).not.toBeNull();
+      expect(sim.lastRun.endReason).toBe('BUDGET_DEPLETED');
+      expect(sim.lastRun.multiplier).toBeLessThan(1.0);
+    });
+
+    it('RATING_COLLAPSED applies 0.50x penalty', () => {
+      const sim = makeSim();
+      sim.reset({ width: 800, height: 600 }, { seed: 1 });
+      sim.running = true;
+      for (let i = 0; i < 10; i++) sim.tick();
+      sim.rating = 0.5;
+      sim.tick();
+      expect(sim.lastRun).not.toBeNull();
+      expect(sim.lastRun.endReason).toBe('RATING_COLLAPSED');
+      expect(sim.lastRun.multiplier).toBeLessThanOrEqual(0.50);
+    });
+  });
+
+  describe('bonuses', () => {
+    it('SHIFT_COMPLETE on JUNIOR_MID gets survived bonus', () => {
+      const sim = makeSim();
+      sim.reset({ width: 800, height: 600 }, { seed: 1 });
+      sim.setPreset('JUNIOR_MID');
+      sim.running = true;
+      // Fast-forward to shift end
+      const shiftDur = sim.getShiftDurationSec();
+      sim.timeSec = shiftDur - 1;
+      sim.tick();
+      expect(sim.lastRun).not.toBeNull();
+      expect(sim.lastRun.endReason).toBe('SHIFT_COMPLETE');
+      const survivedBonus = sim.lastRun.bonuses.find((b: any) => b.id === 'survived');
+      expect(survivedBonus).toBeDefined();
+      expect(survivedBonus.pct).toBe(0.15);
+    });
+
+    it('high rating bonus when rating >= 4.8 at shift end', () => {
+      const sim = makeSim();
+      sim.reset({ width: 800, height: 600 }, { seed: 1 });
+      sim.running = true;
+      const shiftDur = sim.getShiftDurationSec();
+      sim.timeSec = shiftDur - 1;
+      sim.rating = 4.9;
+      sim.tick();
+      if (sim.lastRun && sim.lastRun.endReason === 'SHIFT_COMPLETE') {
+        const highRating = sim.lastRun.bonuses.find((b: any) => b.id === 'high_rating');
+        expect(highRating).toBeDefined();
+        expect(highRating.pct).toBe(0.10);
+      }
+    });
+
+    it('no bonuses on failure endings', () => {
+      const sim = makeSim();
+      sim.reset({ width: 800, height: 600 }, { seed: 1 });
+      sim.running = true;
+      for (let i = 0; i < 10; i++) sim.tick();
+      sim.budget = -1;
+      sim.tick();
+      expect(sim.lastRun).not.toBeNull();
+      expect(sim.lastRun.bonuses).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #34.

Adds scoring differentiation based on how a run ends and preset-specific bonus objectives.

### Failure penalties
- **BUDGET_DEPLETED**: 0.70x multiplier (partial credit for time survived)
- **RATING_COLLAPSED**: 0.50x multiplier (user trust lost)
- **SHIFT_COMPLETE**: 1.0x (no penalty)

### Preset-specific bonuses (SHIFT_COMPLETE only)
- **Junior/Mid**: +15% for surviving the shift
- **Senior**: +20% for zero refills used
- **Staff**: +25% for zero architecture debt at end
- **Principal**: +30% for flawless run (zero incidents + rating >= 4.8)

### Universal bonuses (SHIFT_COMPLETE only)
- **Clean desk**: +10% for zero open tickets at shift end
- **High rating**: +10% for rating >= 4.8 at end

### Implementation
- New `ScoreBonus` type in types.ts with id/label/percentage
- `evaluateBonuses()` and `endRunMultiplier()` methods in GameSim
- Bonuses listed in postmortem summary
- Incident counter (`incidentCount`) added for Principal flawless tracking
- `RunResult.bonuses` field added to carry bonus data to UI

## Test plan

- [x] `npm run build` - clean compile
- [x] `npm run test:unit` - 28/28 pass (5 new scoring tests)
- [x] `npm run test:e2e:ci` - E2E smoke passes
- [x] CI checks pass