### PR TITLE
Add inline sparklines for key metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,7 @@
           <div class="card">
             <div class="k" data-i18n="lbl.rating">Rating</div>
             <div class="v mono" id="rating">5.0 ★</div>
+            <svg id="sparkRating" class="sparkline" aria-hidden="true"></svg>
             <div class="small" data-i18n="hint.rating">Drops from failures / ANRs / slow</div>
           </div>
           <div class="card">
@@ -97,6 +98,7 @@
           <div class="card">
             <div class="k" data-i18n="lbl.failures">Failures</div>
             <div class="v mono" id="fail">0.0%</div>
+            <svg id="sparkFail" class="sparkline" aria-hidden="true"></svg>
             <div class="small" data-i18n="hint.failures">Too many = review bombs</div>
           </div>
           <div class="card">
@@ -123,11 +125,13 @@
           <div class="card">
             <div class="k" data-i18n="lbl.jank">Jank</div>
             <div class="v mono" id="jank">0%</div>
+            <svg id="sparkJank" class="sparkline" aria-hidden="true"></svg>
             <div class="small" data-i18n="hint.jank">FrameGuard 16ms</div>
           </div>
           <div class="card">
             <div class="k" data-i18n="lbl.heap">Heap</div>
             <div class="v mono" id="heap">64 MB</div>
+            <svg id="sparkHeap" class="sparkline" aria-hidden="true"></svg>
             <div class="small"><span data-i18n="heapwatch.gc">HeapWatch GC</span> <span class="mono" id="gc">0</span> <span data-i18n="heapwatch.msOom">ms • OOM</span> <span class="mono" id="oom">0</span></div>
           </div>
         </section>

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { addScoreEntry, clearScoreboard, loadScoreboard, sealScoreboard, verifyS
 import { MODE, Mode, ComponentType, Ticket, EvalPreset, EVAL_PRESET, RefactorAction } from './types';
 import { deriveKey, sealStorageKey, verifyStorageKey, markTampered, getTamperState, isScoreSane, needsMigration, setMigrationDone } from './integrity';
 import './entropy';
+import { Sparkline } from './sparkline';
 import { applyTranslations, getLanguage, loadLanguage, populateLanguageSelect, setLanguage, t, type Lang } from './i18n';
 
 type ThemeMode = 'system' | 'light' | 'dark';
@@ -188,6 +189,12 @@ type UIRefs = {
 
   // Integrity
   integrityBadge: HTMLElement;
+
+  // Sparklines
+  sparkRating: HTMLElement;
+  sparkFail: HTMLElement;
+  sparkJank: HTMLElement;
+  sparkHeap: HTMLElement;
 };
 
 
@@ -201,6 +208,16 @@ if (IS_E2E) document.documentElement.classList.add('e2e');
 
 const refs = bindUI();
 if (IS_E2E) refs.seedInput.value = '12345';
+
+// --- Sparklines -----------------------------------------------------------
+const sparkRating = new Sparkline();
+const sparkFail = new Sparkline();
+const sparkJank = new Sparkline();
+const sparkHeap = new Sparkline();
+sparkRating.bind(refs.sparkRating);
+sparkFail.bind(refs.sparkFail);
+sparkJank.bind(refs.sparkJank);
+sparkHeap.bind(refs.sparkHeap);
 
 // --- Localization ---------------------------------------------------------
 const initLang = loadLanguage();
@@ -937,6 +954,7 @@ refs.btnReset.onclick = () => {
     getCanvasBounds(),
     (seed !== undefined && Number.isFinite(seed)) ? { seed } : undefined
   );
+  sparkRating.reset(); sparkFail.reset(); sparkJank.reset(); sparkHeap.reset();
   fitToView();
   syncUI();
 };
@@ -1452,6 +1470,14 @@ function syncUI() {
   setText(refs.gc, `${Math.round(s.gcPauseMs)}`);
   setText(refs.oom, `${s.oomCount}`);
 
+  // Sparklines: push samples each tick while running.
+  if (sim.running) {
+    sparkRating.push(s.rating);
+    sparkFail.push(s.failureRate * 100);
+    sparkJank.push(s.jankPct);
+    sparkHeap.push(s.heapMb);
+  }
+
   setText(refs.a11yScore, `${Math.round(s.a11yScore)}`);
   setText(refs.privacyTrust, `${Math.round(s.privacyTrust)}`);
   setText(refs.securityPosture, `${Math.round(s.securityPosture)}`);
@@ -1703,6 +1729,11 @@ function bindUI(): UIRefs {
     refactorOptions: must('refactorOptions'),
 
     integrityBadge: must('integrityBadge'),
+
+    sparkRating: must('sparkRating'),
+    sparkFail: must('sparkFail'),
+    sparkJank: must('sparkJank'),
+    sparkHeap: must('sparkHeap'),
   };
 }
 

--- a/src/sparkline.ts
+++ b/src/sparkline.ts
@@ -1,0 +1,58 @@
+/**
+ * Lightweight inline sparkline renderer.
+ * Maintains a rolling buffer of samples and renders as an inline SVG polyline.
+ */
+
+const MAX_SAMPLES = 60; // 60 ticks = 60 seconds of history
+
+export class Sparkline {
+  private samples: number[] = [];
+  private min = 0;
+  private max = 1;
+  private polyline: SVGPolylineElement | null = null;
+
+  constructor(private width = 80, private height = 20) {}
+
+  /** Bind to an existing SVG element in the DOM. */
+  bind(svg: Element): void {
+    svg.setAttribute('viewBox', `0 0 ${this.width} ${this.height}`);
+
+    this.polyline = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
+    this.polyline.setAttribute('fill', 'none');
+    this.polyline.setAttribute('stroke', 'currentColor');
+    this.polyline.setAttribute('stroke-width', '1.5');
+    this.polyline.setAttribute('stroke-linecap', 'round');
+    this.polyline.setAttribute('stroke-linejoin', 'round');
+    svg.appendChild(this.polyline);
+  }
+
+  /** Push a new sample and re-render. */
+  push(value: number): void {
+    this.samples.push(value);
+    if (this.samples.length > MAX_SAMPLES) this.samples.shift();
+    this.render();
+  }
+
+  /** Clear all samples. */
+  reset(): void {
+    this.samples.length = 0;
+    if (this.polyline) this.polyline.setAttribute('points', '');
+  }
+
+  private render(): void {
+    if (!this.polyline || this.samples.length < 2) return;
+
+    this.min = Math.min(...this.samples);
+    this.max = Math.max(...this.samples);
+    const range = this.max - this.min || 1;
+    const pad = 1; // 1px padding top/bottom
+
+    const points = this.samples.map((v, i) => {
+      const x = (i / (this.samples.length - 1)) * this.width;
+      const y = pad + (1 - (v - this.min) / range) * (this.height - pad * 2);
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    }).join(' ');
+
+    this.polyline.setAttribute('points', points);
+  }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -454,6 +454,15 @@ h1 {
   box-shadow: var(--md-elevation-1);
 }
 
+.sparkline {
+  display: block;
+  width: 80px;
+  height: 20px;
+  margin: 2px 0;
+  opacity: 0.55;
+  color: var(--md-sys-color-primary);
+}
+
 /* Badges / chips */
 .badge,
 .pill {


### PR DESCRIPTION
## Summary

Closes #32.

Adds inline SVG sparklines to four key metric cards: rating, failure rate, jank, and heap. The sparklines show a rolling 60-second trend history, making it easy to see whether metrics are improving or degrading.

### Implementation
- **`src/sparkline.ts`** (new): Lightweight sparkline renderer using inline SVG polylines. Maintains a rolling buffer of up to 60 samples, auto-scales Y axis, and renders via a single SVG polyline element. Zero external dependencies.
- **`index.html`**: Added `<svg class="sparkline">` elements inside 4 metric cards (rating, failures, jank, heap)
- **`src/style.css`**: Sparkline styling (80x20px, 55% opacity, primary color)
- **`src/main.ts`**: Creates Sparkline instances, binds to SVG elements, pushes samples each tick while sim is running, resets on game reset

### Design choices
- Sparklines are decorative (`aria-hidden="true"`) since the numeric values are already accessible
- Only sample while the sim is running (no samples while paused)
- Reset sparkline data on game reset for a clean start
- Subtle opacity (55%) to avoid overwhelming the numeric values

## Test plan

- [x] `npm run build` - clean compile (14 modules)
- [x] `npm run test:dom` - 113 DOM IDs validated (+4 sparklines)
- [x] `npm run test:e2e:ci` - E2E smoke passes
- [x] CI checks pass
- [ ] Manual: start game, observe sparklines animating in metric cards