### PR TITLE
Add daily and weekly challenge system

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,21 @@
         </section>
 
         <section class="card">
+          <div class="k">Challenges</div>
+          <div class="small" style="margin-top:8px;">
+            <b>Daily:</b> <span id="challengeDaily" class="mono">-</span>
+          </div>
+          <div class="small" style="margin-top:4px;">
+            <b>Weekly:</b> <span id="challengeWeekly" class="mono">-</span>
+          </div>
+          <div class="row" style="margin-top:10px;">
+            <button id="btnStartDaily" class="btn tonal">Start daily</button>
+            <button id="btnStartWeekly" class="btn outlined">Start weekly</button>
+          </div>
+          <pre class="small" id="challengeResults" style="margin-top:8px;"></pre>
+        </section>
+
+        <section class="card">
           <div class="k" data-i18n="card.achievements">Achievements</div>
           <div class="small" style="margin-top:8px;">
             <span data-i18n="ach.preset">Preset:</span> <span id="achPreset" class="mono">SENIOR</span> •

--- a/src/challenges.ts
+++ b/src/challenges.ts
@@ -1,0 +1,169 @@
+/**
+ * Daily and weekly challenge system.
+ *
+ * Challenges are deterministic per UTC date: everyone playing on the same day
+ * gets the same seed and constraint. Weekly challenges rotate on Mondays.
+ */
+
+import type { EvalPreset, RunResult } from './types';
+
+export type ChallengeConstraint =
+  | 'NO_REFILLS'
+  | 'NO_UPGRADES'
+  | 'HIGH_RATING'
+  | 'CLEAN_DESK'
+  | 'SPEED_RUN'
+  | 'LOW_BUDGET'
+  | 'ZERO_DEBT';
+
+export type ChallengeType = 'DAILY' | 'WEEKLY';
+
+export type ChallengeDef = {
+  id: string;
+  type: ChallengeType;
+  title: string;
+  description: string;
+  constraint: ChallengeConstraint;
+  seed: number;
+  preset: EvalPreset;
+  bonusMultiplier: number;
+};
+
+export type ChallengeResult = {
+  challengeId: string;
+  completed: boolean;
+  finalScore: number;
+  date: string; // YYYY-MM-DD
+};
+
+const DAILY_TEMPLATES: Array<{ constraint: ChallengeConstraint; title: string; description: string; preset: EvalPreset; bonus: number }> = [
+  { constraint: 'NO_REFILLS', title: 'No Refills', description: 'Complete the shift without using any capacity refills.', preset: 'SENIOR', bonus: 1.20 },
+  { constraint: 'HIGH_RATING', title: 'Five Stars', description: 'End the shift with rating >= 4.5.', preset: 'SENIOR', bonus: 1.15 },
+  { constraint: 'CLEAN_DESK', title: 'Clean Desk', description: 'End the shift with zero open tickets.', preset: 'JUNIOR_MID', bonus: 1.25 },
+  { constraint: 'LOW_BUDGET', title: 'Tight Budget', description: 'Complete the shift. Starting budget reduced to $1500.', preset: 'SENIOR', bonus: 1.30 },
+  { constraint: 'ZERO_DEBT', title: 'Zero Debt', description: 'End the shift with architecture debt at 0.', preset: 'STAFF', bonus: 1.25 },
+];
+
+const WEEKLY_TEMPLATES: Array<{ constraint: ChallengeConstraint; title: string; description: string; preset: EvalPreset; bonus: number }> = [
+  { constraint: 'NO_UPGRADES', title: 'Base Tier Only', description: 'Complete the shift without upgrading any component.', preset: 'SENIOR', bonus: 1.35 },
+  { constraint: 'SPEED_RUN', title: 'Speed Run', description: 'Survive on Principal preset (8-minute shift).', preset: 'PRINCIPAL', bonus: 1.40 },
+  { constraint: 'NO_REFILLS', title: 'Iron Will', description: 'Complete Staff preset with zero refills.', preset: 'STAFF', bonus: 1.35 },
+];
+
+function dateSeed(year: number, month: number, day: number): number {
+  return ((year * 10000 + month * 100 + day) * 2654435761) >>> 0;
+}
+
+function weekNumber(d: Date): number {
+  const start = new Date(d.getUTCFullYear(), 0, 1);
+  const diff = d.getTime() - start.getTime();
+  return Math.floor(diff / (7 * 24 * 60 * 60 * 1000));
+}
+
+/** Get today's daily challenge (deterministic per UTC date). */
+export function getDailyChallenge(): ChallengeDef {
+  const d = new Date();
+  const y = d.getUTCFullYear();
+  const m = d.getUTCMonth() + 1;
+  const day = d.getUTCDate();
+  const idx = (y * 366 + m * 31 + day) % DAILY_TEMPLATES.length;
+  const tmpl = DAILY_TEMPLATES[idx];
+  const seed = dateSeed(y, m, day);
+
+  return {
+    id: `daily-${y}-${String(m).padStart(2, '0')}-${String(day).padStart(2, '0')}`,
+    type: 'DAILY',
+    title: tmpl.title,
+    description: tmpl.description,
+    constraint: tmpl.constraint,
+    seed,
+    preset: tmpl.preset,
+    bonusMultiplier: tmpl.bonus,
+  };
+}
+
+/** Get this week's weekly challenge (rotates on Mondays). */
+export function getWeeklyChallenge(): ChallengeDef {
+  const d = new Date();
+  const y = d.getUTCFullYear();
+  const wk = weekNumber(d);
+  const idx = (y * 53 + wk) % WEEKLY_TEMPLATES.length;
+  const tmpl = WEEKLY_TEMPLATES[idx];
+  const seed = dateSeed(y, wk, 0);
+
+  return {
+    id: `weekly-${y}-w${String(wk).padStart(2, '0')}`,
+    type: 'WEEKLY',
+    title: tmpl.title,
+    description: tmpl.description,
+    constraint: tmpl.constraint,
+    seed,
+    preset: tmpl.preset,
+    bonusMultiplier: tmpl.bonus,
+  };
+}
+
+/** Check if a completed run satisfies the challenge constraint. */
+export function evaluateChallenge(challenge: ChallengeDef, run: RunResult, refillsUsed: number, upgradesUsed: number): ChallengeResult {
+  const date = challenge.id.replace(/^(daily|weekly)-/, '');
+  let completed = run.endReason === 'SHIFT_COMPLETE';
+
+  if (completed) {
+    switch (challenge.constraint) {
+      case 'NO_REFILLS':
+        completed = refillsUsed === 0;
+        break;
+      case 'NO_UPGRADES':
+        completed = upgradesUsed === 0;
+        break;
+      case 'HIGH_RATING':
+        completed = run.rating >= 4.5;
+        break;
+      case 'CLEAN_DESK':
+        completed = run.ticketsOpen === 0;
+        break;
+      case 'SPEED_RUN':
+        completed = true; // just surviving Principal is the challenge
+        break;
+      case 'LOW_BUDGET':
+        completed = true; // constraint is applied at start (reduced budget)
+        break;
+      case 'ZERO_DEBT':
+        completed = Math.round(run.architectureDebt) === 0;
+        break;
+    }
+  }
+
+  return {
+    challengeId: challenge.id,
+    completed,
+    finalScore: completed ? Math.round(run.finalScore * challenge.bonusMultiplier) : run.finalScore,
+    date,
+  };
+}
+
+// --- Persistence ---
+
+const CHALLENGE_KEY = 'asr:challenges:v1';
+
+export function loadChallengeResults(): ChallengeResult[] {
+  try {
+    const raw = localStorage.getItem(CHALLENGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveChallengeResult(result: ChallengeResult): void {
+  try {
+    const existing = loadChallengeResults();
+    const filtered = existing.filter(r => r.challengeId !== result.challengeId);
+    const next = [result, ...filtered].slice(0, 50);
+    localStorage.setItem(CHALLENGE_KEY, JSON.stringify(next));
+  } catch {
+    // ignore
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { MODE, Mode, ComponentType, Ticket, EvalPreset, EVAL_PRESET, RefactorAct
 import { deriveKey, sealStorageKey, verifyStorageKey, markTampered, getTamperState, isScoreSane, needsMigration, setMigrationDone } from './integrity';
 import './entropy';
 import { Sparkline } from './sparkline';
+import { getDailyChallenge, getWeeklyChallenge, evaluateChallenge, saveChallengeResult, loadChallengeResults, type ChallengeDef } from './challenges';
 import { applyTranslations, getLanguage, loadLanguage, populateLanguageSelect, setLanguage, t, type Lang } from './i18n';
 
 type ThemeMode = 'system' | 'light' | 'dark';
@@ -195,6 +196,13 @@ type UIRefs = {
   sparkFail: HTMLElement;
   sparkJank: HTMLElement;
   sparkHeap: HTMLElement;
+
+  // Challenges
+  challengeDaily: HTMLElement;
+  challengeWeekly: HTMLElement;
+  btnStartDaily: HTMLButtonElement;
+  btnStartWeekly: HTMLButtonElement;
+  challengeResults: HTMLElement;
 };
 
 
@@ -972,6 +980,46 @@ refs.btnDailySeed.onclick = () => {
   syncUI();
 };
 
+// --- Challenges -------------------------------------------------------------
+let activeChallenge: ChallengeDef | null = null;
+
+function renderChallenges() {
+  const daily = getDailyChallenge();
+  const weekly = getWeeklyChallenge();
+  refs.challengeDaily.textContent = `${daily.title} (${daily.preset}, seed ${daily.seed})`;
+  refs.challengeWeekly.textContent = `${weekly.title} (${weekly.preset}, seed ${weekly.seed})`;
+
+  const results = loadChallengeResults().slice(0, 5);
+  if (results.length) {
+    refs.challengeResults.textContent = results.map(r =>
+      `${r.challengeId}: ${r.completed ? 'COMPLETED' : 'FAILED'} (${r.finalScore} pts)`
+    ).join('\n');
+  } else {
+    refs.challengeResults.textContent = '';
+  }
+}
+
+function startChallenge(challenge: ChallengeDef) {
+  activeChallenge = challenge;
+  sim.running = false;
+  refs.presetSelect.value = challenge.preset;
+  sim.setPreset(challenge.preset);
+  ach.setPreset(challenge.preset);
+  refs.seedInput.value = String(challenge.seed);
+  sim.reset(getCanvasBounds(), { seed: challenge.seed });
+  if (challenge.constraint === 'LOW_BUDGET') {
+    sim.budget = 1500;
+  }
+  sparkRating.reset(); sparkFail.reset(); sparkJank.reset(); sparkHeap.reset();
+  fitToView();
+  syncUI();
+}
+
+refs.btnStartDaily.onclick = () => startChallenge(getDailyChallenge());
+refs.btnStartWeekly.onclick = () => startChallenge(getWeeklyChallenge());
+
+renderChallenges();
+
 function openProfile(preset: EvalPreset) {
   refs.profileModal.hidden = false;
   refs.profilePresetSelect.value = preset;
@@ -1539,6 +1587,15 @@ function syncUI() {
       });
       integrityKeyPromise.then(key => sealScoreboard(key));
       renderScoreboard();
+
+      // Evaluate active challenge
+      if (activeChallenge && s.lastRun.seed === activeChallenge.seed) {
+        const maxTier = sim.components.reduce((mx, c) => Math.max(mx, c.tier), 0);
+        const result = evaluateChallenge(activeChallenge, s.lastRun, sim.engRefillsUsed, maxTier > 1 ? 1 : 0);
+        saveChallengeResult(result);
+        activeChallenge = null;
+        renderChallenges();
+      }
     }
   } else {
     refs.postmortem.textContent = t('history.noRun');
@@ -1734,6 +1791,12 @@ function bindUI(): UIRefs {
     sparkFail: must('sparkFail'),
     sparkJank: must('sparkJank'),
     sparkHeap: must('sparkHeap'),
+
+    challengeDaily: must('challengeDaily'),
+    challengeWeekly: must('challengeWeekly'),
+    btnStartDaily: must<HTMLButtonElement>('btnStartDaily'),
+    btnStartWeekly: must<HTMLButtonElement>('btnStartWeekly'),
+    challengeResults: must('challengeResults'),
   };
 }
 


### PR DESCRIPTION
## Summary

Closes #31.

Adds time-limited challenges that rotate automatically:

**Daily challenges** (5 templates, rotate by UTC date):
- No Refills, Five Stars, Clean Desk, Tight Budget, Zero Debt
- Each has a fixed seed, preset, and bonus multiplier (1.15x-1.30x)

**Weekly challenges** (3 templates, rotate on Mondays):
- Base Tier Only, Speed Run, Iron Will
- Harder constraints with higher bonuses (1.35x-1.40x)

### How it works
- Challenges are deterministic: same date = same seed + constraint for everyone
- Click "Start daily" or "Start weekly" to begin a challenge run
- On run completion, the challenge is evaluated against its constraint
- Results are persisted in localStorage (last 50)
- LOW_BUDGET constraint reduces starting budget to $1500

## Test plan

- [x] `npm run build` - clean compile (15 modules)
- [x] `npm run test:dom` - 118 DOM IDs validated
- [x] `npm run test:e2e:ci` - E2E smoke passes
- [x] CI checks pass