### PR TITLE
Extract PlatformPulse, CoverageGate, and RegMatrix into subsystems module

### DIFF
--- a/src/sim.ts
+++ b/src/sim.ts
@@ -21,6 +21,7 @@ const COMPONENT_DEPS: Record<string, Array<'net' | 'image' | 'json' | 'auth' | '
 import { ACTION_KEYS, ActionDef, ActionKey, Link, MODE, Mode, Component, ComponentDef, ComponentType, Request, Ticket, TicketKind, TicketSeverity, Advisory, PlatformState, RegionState, RegionCode, EvalPreset, EVAL_PRESET, RunResult, EndReason, ScoreBonus, RefactorOption, RefactorAction, ArchViolation, RefactorRoadmapStep } from './types';
 import { Rng } from './rng';
 import { entropyPool } from './entropy';
+import { tickPlatformPulse as platformPulseTick, tickCoverageGate as coverageGateTick, computeRegionTarget, type CoverageGateInput } from './subsystems';
 
 export const ComponentDefs: Record<ComponentType, ComponentDef> = {
   // Core layers (Android mental model, not backend microservices)
@@ -1013,32 +1014,13 @@ export class GameSim {
   }
 
   private tickPlatformPulse() {
-    // Market shifts slowly away from old devices
-    this.platform.oldDeviceShare = clamp(this.platform.oldDeviceShare - 0.00018, 0.06, 0.40);
-    this.platform.lowRamShare = clamp(this.platform.lowRamShare - 0.00015, 0.08, 0.45);
-
-    // New Android release event occasionally (kept frequent for game pacing)
-    if (this.timeSec > 0 && this.timeSec % 180 === 0) {
-      if (this.rand() < 0.35) {
-        this.platform.latestApi += 1;
-        this.platform.pressure = clamp(this.platform.pressure + 0.65, 0, 1);
-        this.addEvent(`New Android API ${this.platform.latestApi} released`);
-      }
+    const result = platformPulseTick(this.platform, this.timeSec, () => this.rand());
+    this.platform = result.platform;
+    if (result.newApiReleased) {
+      this.addEvent(`New Android API ${this.platform.latestApi} released`);
     }
-
-    // Pressure decays as teams patch and users update
-    this.platform.pressure = clamp(this.platform.pressure * 0.985 - 0.0005, 0, 1);
-
-    // Optional deprecation hint: if old share is small, dropping min SDK becomes tempting
-    if (this.timeSec % 240 === 0 && this.platform.oldDeviceShare < 0.12 && this.platform.minApi < this.platform.latestApi - 9) {
-      this.createTicket(
-        'COMPAT_ANDROID',
-        `Consider dropping API ${this.platform.minApi} support`,
-        'Platform',
-        1,
-        35,
-        3
-      );
+    if (result.deprecationTicket) {
+      this.createTicket('COMPAT_ANDROID', `Consider dropping API ${this.platform.minApi} support`, 'Platform', 1, 35, 3);
     }
   }
 
@@ -1093,29 +1075,17 @@ export class GameSim {
 
 
   private regionTarget(code: RegionCode) {
-    const base = (
-      0.45 * this.privacyTrust +
-      0.40 * this.securityPosture +
-      0.15 * this.a11yScore
-    );
-
-    let strictPrivacy = 0;
-    let strictSecurity = 0;
-    if (code === 'EU') { strictPrivacy = 10; strictSecurity = 4; }
-    if (code === 'UK') { strictPrivacy = 8; strictSecurity = 4; }
-    if (code === 'US') { strictPrivacy = 2; strictSecurity = 10; }
-    if (code === 'IN') { strictPrivacy = 4; strictSecurity = 6; }
-    if (code === 'BR') { strictPrivacy = 6; strictSecurity = 6; }
-
-    const hasFlags = this.tierOf('FLAGS') >= 1 ? 1 : 0;
-    const hasObs = this.tierOf('OBS') >= 1 ? 1 : 0;
-    const hasKeystore = this.tierOf('KEYSTORE') >= 1 ? 1 : 0;
-    const hasSan = this.tierOf('SANITIZER') >= 1 ? 1 : 0;
-
-    const controlBoost = 2.0 * hasFlags + 1.5 * hasObs + 2.0 * hasKeystore + 1.5 * hasSan;
-    const platformPenalty = this.platform.pressure * 8;
-
-    return clamp(base + controlBoost - platformPenalty - strictPrivacy - strictSecurity, 35, 98);
+    return computeRegionTarget({
+      code,
+      privacyTrust: this.privacyTrust,
+      securityPosture: this.securityPosture,
+      a11yScore: this.a11yScore,
+      flagsTier: this.tierOf('FLAGS'),
+      obsTier: this.tierOf('OBS'),
+      keystoreTier: this.tierOf('KEYSTORE'),
+      sanitizerTier: this.tierOf('SANITIZER'),
+      platformPressure: this.platform.pressure,
+    });
   }
 
   private tickRegMatrix() {
@@ -1178,52 +1148,30 @@ export class GameSim {
   }
 
 private tickCoverageGate() {
-  // Track recent coverage so we can detect sharp drops ("escaped regressions").
-  // Important: compute drop against the *previous* recent max (pre-current-tick mutations),
-  // otherwise an instantaneous drop (e.g., adding many components at once) won't be visible.
-  if (this.coverageHist.length === 0) this.coverageHist.push(this.coveragePct);
-  if (this.coverageHist.length > 90) this.coverageHist.shift();
-  const maxRecentBefore = Math.max(...this.coverageHist);
-
-  const compCount = this.components.length;
-  const added = Math.max(0, compCount - this.lastCompCount);
-  this.lastCompCount = compCount;
-
-  const addTax =
-    (this.preset === EVAL_PRESET.JUNIOR_MID) ? 0.35 :
-    (this.preset === EVAL_PRESET.SENIOR) ? 0.55 :
-    (this.preset === EVAL_PRESET.STAFF) ? 0.70 : 0.85;
-  if (added > 0) this.coveragePct = clamp(this.coveragePct - added * addTax, 0, 100);
-
-  const baseDecay =
-    (this.preset === EVAL_PRESET.JUNIOR_MID) ? 0.010 :
-    (this.preset === EVAL_PRESET.SENIOR) ? 0.016 :
-    (this.preset === EVAL_PRESET.STAFF) ? 0.022 : 0.026;
-  const churn = (this.platform.pressure * 0.030) + (this.regPressure / 100) * 0.010;
-  const complexity = clamp(compCount / 30, 0, 1) * 0.020;
-  const decay = (baseDecay + churn + complexity) * (1 - this.qualityProcess * 0.55);
-  this.coveragePct = clamp(this.coveragePct - decay, 0, 100);
-
-  const below = Math.max(0, this.coverageThreshold - this.coveragePct);
-  const severityW =
-    (this.preset === EVAL_PRESET.JUNIOR_MID) ? 0.55 :
-    (this.preset === EVAL_PRESET.SENIOR) ? 1.0 :
-    (this.preset === EVAL_PRESET.STAFF) ? 1.20 : 1.35;
-  const penalty = clamp(below / this.coverageThreshold, 0, 1) * severityW;
-  this.coverageRiskMult = 1 + penalty * 0.40;
-
-  if (this.coveragePct < this.coverageThreshold) {
+  const input: CoverageGateInput = {
+    coveragePct: this.coveragePct,
+    coverageHist: this.coverageHist,
+    lastCompCount: this.lastCompCount,
+    componentCount: this.components.length,
+    preset: this.preset,
+    platformPressure: this.platform.pressure,
+    regPressure: this.regPressure,
+    qualityProcess: this.qualityProcess,
+    coverageThreshold: this.coverageThreshold,
+    timeSec: this.timeSec,
+  };
+  const result = coverageGateTick(input);
+  this.coveragePct = result.coveragePct;
+  this.coverageHist = result.coverageHist;
+  this.lastCompCount = result.lastCompCount;
+  this.coverageRiskMult = result.coverageRiskMult;
+  if (result.belowThresholdTicket) {
     this.createTicket('TEST_COVERAGE', `Test coverage below ${this.coverageThreshold}%`, 'Reliability', 2, 68, 4);
   }
-
-  const drop = maxRecentBefore - this.coveragePct;
-  if (drop >= 10 && this.timeSec % 30 === 0) {
+  if (result.regressionCrash) {
     this.addEvent('Escaped regression due to low coverage');
     this.createTicket('CRASH_SPIKE', 'Regression crash spike', 'Reliability', 3, 85, 5);
   }
-
-  this.coverageHist.push(this.coveragePct);
-  if (this.coverageHist.length > 90) this.coverageHist.shift();
 }
 
 

--- a/src/subsystems.ts
+++ b/src/subsystems.ts
@@ -1,0 +1,164 @@
+/**
+ * Extracted simulation subsystem logic.
+ *
+ * Each function takes a read-only view of the state it needs and returns
+ * a mutation descriptor. GameSim remains the orchestrator that applies
+ * mutations and owns all mutable state.
+ */
+
+import type { PlatformState, RegionCode, EvalPreset } from './types';
+
+// ---------------------------------------------------------------------------
+// PlatformPulse
+// ---------------------------------------------------------------------------
+
+export type PlatformPulseResult = {
+  platform: PlatformState;
+  newApiReleased: boolean;
+  deprecationTicket: boolean;
+};
+
+export function tickPlatformPulse(
+  platform: PlatformState,
+  timeSec: number,
+  randFn: () => number,
+): PlatformPulseResult {
+  const p = { ...platform };
+  p.oldDeviceShare = clamp(p.oldDeviceShare - 0.00018, 0.06, 0.40);
+  p.lowRamShare = clamp(p.lowRamShare - 0.00015, 0.08, 0.45);
+
+  let newApiReleased = false;
+  if (timeSec > 0 && timeSec % 180 === 0 && randFn() < 0.35) {
+    p.latestApi += 1;
+    p.pressure = clamp(p.pressure + 0.65, 0, 1);
+    newApiReleased = true;
+  }
+
+  p.pressure = clamp(p.pressure * 0.985 - 0.0005, 0, 1);
+
+  const deprecationTicket = (
+    timeSec % 240 === 0 &&
+    p.oldDeviceShare < 0.12 &&
+    p.minApi < p.latestApi - 9
+  );
+
+  return { platform: p, newApiReleased, deprecationTicket };
+}
+
+// ---------------------------------------------------------------------------
+// CoverageGate
+// ---------------------------------------------------------------------------
+
+export type CoverageGateInput = {
+  coveragePct: number;
+  coverageHist: number[];
+  lastCompCount: number;
+  componentCount: number;
+  preset: EvalPreset;
+  platformPressure: number;
+  regPressure: number;
+  qualityProcess: number;
+  coverageThreshold: number;
+  timeSec: number;
+};
+
+export type CoverageGateResult = {
+  coveragePct: number;
+  coverageHist: number[];
+  lastCompCount: number;
+  coverageRiskMult: number;
+  belowThresholdTicket: boolean;
+  regressionCrash: boolean;
+};
+
+export function tickCoverageGate(input: CoverageGateInput): CoverageGateResult {
+  const hist = [...input.coverageHist];
+  if (hist.length === 0) hist.push(input.coveragePct);
+  if (hist.length > 90) hist.shift();
+  const maxRecentBefore = Math.max(...hist);
+
+  let coveragePct = input.coveragePct;
+  const added = Math.max(0, input.componentCount - input.lastCompCount);
+
+  const PRESETS: Record<string, { addTax: number; baseDecay: number; severityW: number }> = {
+    JUNIOR_MID: { addTax: 0.35, baseDecay: 0.010, severityW: 0.55 },
+    SENIOR:     { addTax: 0.55, baseDecay: 0.016, severityW: 1.0 },
+    STAFF:      { addTax: 0.70, baseDecay: 0.022, severityW: 1.20 },
+    PRINCIPAL:  { addTax: 0.85, baseDecay: 0.026, severityW: 1.35 },
+  };
+  const p = PRESETS[input.preset] ?? PRESETS.SENIOR;
+
+  if (added > 0) coveragePct = clamp(coveragePct - added * p.addTax, 0, 100);
+
+  const churn = input.platformPressure * 0.030 + (input.regPressure / 100) * 0.010;
+  const complexity = clamp(input.componentCount / 30, 0, 1) * 0.020;
+  const decay = (p.baseDecay + churn + complexity) * (1 - input.qualityProcess * 0.55);
+  coveragePct = clamp(coveragePct - decay, 0, 100);
+
+  const below = Math.max(0, input.coverageThreshold - coveragePct);
+  const penalty = clamp(below / input.coverageThreshold, 0, 1) * p.severityW;
+  const coverageRiskMult = 1 + penalty * 0.40;
+
+  const belowThresholdTicket = coveragePct < input.coverageThreshold;
+
+  const drop = maxRecentBefore - coveragePct;
+  const regressionCrash = drop >= 10 && input.timeSec % 30 === 0;
+
+  hist.push(coveragePct);
+  if (hist.length > 90) hist.shift();
+
+  return {
+    coveragePct,
+    coverageHist: hist,
+    lastCompCount: input.componentCount,
+    coverageRiskMult,
+    belowThresholdTicket,
+    regressionCrash,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RegMatrix: region target computation
+// ---------------------------------------------------------------------------
+
+export type RegionTargetInput = {
+  code: RegionCode;
+  privacyTrust: number;
+  securityPosture: number;
+  a11yScore: number;
+  flagsTier: number;
+  obsTier: number;
+  keystoreTier: number;
+  sanitizerTier: number;
+  platformPressure: number;
+};
+
+export function computeRegionTarget(input: RegionTargetInput): number {
+  const base = 0.45 * input.privacyTrust + 0.40 * input.securityPosture + 0.15 * input.a11yScore;
+
+  let strictPrivacy = 0;
+  let strictSecurity = 0;
+  if (input.code === 'EU') { strictPrivacy = 10; strictSecurity = 4; }
+  if (input.code === 'UK') { strictPrivacy = 8; strictSecurity = 4; }
+  if (input.code === 'US') { strictPrivacy = 2; strictSecurity = 10; }
+  if (input.code === 'IN') { strictPrivacy = 4; strictSecurity = 6; }
+  if (input.code === 'BR') { strictPrivacy = 6; strictSecurity = 6; }
+
+  const hasFlags = input.flagsTier >= 1 ? 1 : 0;
+  const hasObs = input.obsTier >= 1 ? 1 : 0;
+  const hasKeystore = input.keystoreTier >= 1 ? 1 : 0;
+  const hasSan = input.sanitizerTier >= 1 ? 1 : 0;
+
+  const controlBoost = 2.0 * hasFlags + 1.5 * hasObs + 2.0 * hasKeystore + 1.5 * hasSan;
+  const platformPenalty = input.platformPressure * 8;
+
+  return clamp(base + controlBoost - platformPenalty - strictPrivacy - strictSecurity, 35, 98);
+}
+
+// ---------------------------------------------------------------------------
+// Shared utility
+// ---------------------------------------------------------------------------
+
+function clamp(x: number, a: number, b: number) {
+  return Math.max(a, Math.min(b, x));
+}

--- a/tests/unit/subsystems.test.ts
+++ b/tests/unit/subsystems.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { tickPlatformPulse, tickCoverageGate, computeRegionTarget } from '../../src/subsystems';
+
+describe('PlatformPulse', () => {
+  it('decays old device share over time', () => {
+    const platform = { latestApi: 35, minApi: 26, oldDeviceShare: 0.28, lowRamShare: 0.30, pressure: 0 };
+    const result = tickPlatformPulse(platform, 1, () => 0.5);
+    expect(result.platform.oldDeviceShare).toBeLessThan(0.28);
+    expect(result.platform.lowRamShare).toBeLessThan(0.30);
+  });
+
+  it('triggers new API release at correct interval', () => {
+    const platform = { latestApi: 35, minApi: 26, oldDeviceShare: 0.28, lowRamShare: 0.30, pressure: 0 };
+    const result = tickPlatformPulse(platform, 180, () => 0.1); // rand < 0.35
+    expect(result.newApiReleased).toBe(true);
+    expect(result.platform.latestApi).toBe(36);
+  });
+
+  it('does not trigger API release when rand is high', () => {
+    const platform = { latestApi: 35, minApi: 26, oldDeviceShare: 0.28, lowRamShare: 0.30, pressure: 0 };
+    const result = tickPlatformPulse(platform, 180, () => 0.9);
+    expect(result.newApiReleased).toBe(false);
+  });
+});
+
+describe('CoverageGate', () => {
+  it('decays coverage each tick', () => {
+    const result = tickCoverageGate({
+      coveragePct: 80,
+      coverageHist: [80],
+      lastCompCount: 5,
+      componentCount: 5,
+      preset: 'SENIOR',
+      platformPressure: 0,
+      regPressure: 0,
+      qualityProcess: 0,
+      coverageThreshold: 70,
+      timeSec: 10,
+    });
+    expect(result.coveragePct).toBeLessThan(80);
+    expect(result.belowThresholdTicket).toBe(false);
+  });
+
+  it('flags below-threshold', () => {
+    const result = tickCoverageGate({
+      coveragePct: 60,
+      coverageHist: [60],
+      lastCompCount: 0,
+      componentCount: 0,
+      preset: 'SENIOR',
+      platformPressure: 0,
+      regPressure: 0,
+      qualityProcess: 0,
+      coverageThreshold: 70,
+      timeSec: 10,
+    });
+    expect(result.belowThresholdTicket).toBe(true);
+  });
+
+  it('applies component add tax', () => {
+    const result = tickCoverageGate({
+      coveragePct: 80,
+      coverageHist: [80],
+      lastCompCount: 3,
+      componentCount: 6, // +3 added
+      preset: 'SENIOR',
+      platformPressure: 0,
+      regPressure: 0,
+      qualityProcess: 0,
+      coverageThreshold: 70,
+      timeSec: 10,
+    });
+    // 3 added * 0.55 tax = 1.65 drop + decay
+    expect(result.coveragePct).toBeLessThan(78.35);
+  });
+});
+
+describe('computeRegionTarget', () => {
+  it('returns higher target for stable trust metrics', () => {
+    const target = computeRegionTarget({
+      code: 'US',
+      privacyTrust: 100,
+      securityPosture: 100,
+      a11yScore: 100,
+      flagsTier: 0,
+      obsTier: 0,
+      keystoreTier: 0,
+      sanitizerTier: 0,
+      platformPressure: 0,
+    });
+    expect(target).toBeGreaterThan(80);
+  });
+
+  it('EU has stricter privacy requirements', () => {
+    const base = { privacyTrust: 80, securityPosture: 80, a11yScore: 80, flagsTier: 0, obsTier: 0, keystoreTier: 0, sanitizerTier: 0, platformPressure: 0 };
+    const eu = computeRegionTarget({ ...base, code: 'EU' });
+    const us = computeRegionTarget({ ...base, code: 'US' });
+    // EU has stricter privacy (10 vs 2) but less security (4 vs 10)
+    // Net: EU penalty = 14, US penalty = 12, so EU target should be lower
+    expect(eu).toBeLessThan(us);
+  });
+
+  it('component tiers boost target', () => {
+    const base = { code: 'US' as const, privacyTrust: 60, securityPosture: 60, a11yScore: 60, platformPressure: 0 };
+    const without = computeRegionTarget({ ...base, flagsTier: 0, obsTier: 0, keystoreTier: 0, sanitizerTier: 0 });
+    const withTiers = computeRegionTarget({ ...base, flagsTier: 1, obsTier: 1, keystoreTier: 1, sanitizerTier: 1 });
+    expect(withTiers).toBeGreaterThan(without);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #37 (partial: 3 of 8 subsystems extracted).

Extracts the three most self-contained simulation subsystems from the monolithic `GameSim` class into pure functions in a new `src/subsystems.ts` module. GameSim remains the orchestrator that owns state and applies mutations.

### Extracted subsystems

**PlatformPulse** (`tickPlatformPulse`):
- Takes platform state + time + random function, returns updated state + event flags
- GameSim applies the returned state and creates tickets/events as needed

**CoverageGate** (`tickCoverageGate`):
- Takes a `CoverageGateInput` struct with all needed fields, returns mutations + ticket flags
- Preset-specific constants (addTax, baseDecay, severityW) are now in a lookup table
- GameSim applies coverage updates and creates tickets based on boolean flags

**RegMatrix region target** (`computeRegionTarget`):
- Pure function computing compliance target for a given region
- Replaces the `regionTarget()` private method

### Architecture pattern
Each extracted function follows input/output typing:
- Takes an immutable input struct (no `this` references)
- Returns a result struct with new values + boolean flags for side effects
- GameSim applies results and handles side effects (tickets, events, logging)

This pattern makes the subsystem logic unit-testable in isolation. The remaining 5 subsystems (ZeroDayPulse, FrameGuard, HeapWatch, IncidentSystem, TicketFlow) can follow the same pattern in future PRs.

## Test plan

- [x] `npm run build` - clean compile (16 modules)
- [x] `npm run test:unit` - 37/37 pass (9 new subsystem tests)
- [x] All existing sim tests pass (behavior unchanged)
- [x] CI checks pass