### PR TITLE
Add 6 E2E tests for core game flows

### DIFF
--- a/tests/e2e/core-flows.spec.ts
+++ b/tests/e2e/core-flows.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+
+test('preset switching updates coverage threshold', async ({ page }) => {
+  await page.goto('/');
+
+  await page.selectOption('#presetSelect', 'STAFF');
+  await page.waitForTimeout(500);
+
+  const hint = await page.locator('#coverageHint').innerText();
+  expect(hint).toContain('75');
+});
+
+test('profile modal opens and closes', async ({ page }) => {
+  await page.goto('/');
+
+  // Open profile
+  await page.click('#btnProfile');
+  await expect(page.locator('#profileModal')).toBeVisible();
+
+  // Close with close button
+  await page.click('#btnCloseProfile');
+  await expect(page.locator('#profileModal')).toBeHidden();
+});
+
+test('budget decreases while game is running', async ({ page }) => {
+  await page.goto('/');
+
+  const before = await page.locator('#budget').innerText();
+  await page.click('#btnStart');
+  await page.waitForTimeout(3200);
+  await page.click('#btnPause');
+  const after = await page.locator('#budget').innerText();
+
+  const parseBudget = (s: string) => parseInt(s.replace(/[$,]/g, ''), 10);
+  expect(parseBudget(after)).toBeLessThan(parseBudget(before));
+});
+
+test('tab buttons toggle selection state', async ({ page }) => {
+  await page.goto('/');
+
+  // Backlog tab should become selected
+  await page.click('#tabBtnBacklog');
+  await expect(page.locator('#tabBtnBacklog')).toHaveClass(/is-selected/);
+  await expect(page.locator('#tabBtnOverview')).not.toHaveClass(/is-selected/);
+
+  // History tab
+  await page.click('#tabBtnHistory');
+  await expect(page.locator('#tabBtnHistory')).toHaveClass(/is-selected/);
+  await expect(page.locator('#tabBtnBacklog')).not.toHaveClass(/is-selected/);
+});
+
+test('daily seed button fills seed input', async ({ page }) => {
+  await page.goto('/');
+
+  await page.click('#btnDailySeed');
+  const seedVal = await page.locator('#seedInput').inputValue();
+  expect(seedVal).not.toBe('');
+  expect(parseInt(seedVal, 10)).toBeGreaterThan(0);
+});
+
+test('score increases after running for a few ticks', async ({ page }) => {
+  await page.goto('/');
+
+  await page.click('#btnStart');
+  await page.waitForTimeout(4200); // ~4 ticks
+  await page.click('#btnPause');
+
+  const score = parseInt(await page.locator('#score').innerText(), 10);
+  expect(score).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary

Closes #36.

Adds 6 new E2E tests covering core game flows beyond the existing smoke test:

1. **Preset switching**: Change to Staff, verify coverage threshold shows 75%
2. **Profile modal**: Open and close profile modal
3. **Budget decreases**: Start game, verify budget drops after 3 ticks
4. **Tab navigation**: Click tab buttons, verify selection state toggles
5. **Daily seed button**: Click daily seed, verify input populated with a positive number
6. **Score increases**: Run game for 4 ticks, verify score > 0

All tests use the fixed E2E seed (12345) for determinism. Total E2E suite: 7 tests (1 existing smoke + 6 new).

## Test plan

- [x] `npm run test:e2e:ci` - 7/7 E2E tests pass
- [x] `npm run test:dom` - 118 DOM IDs validated
- [x] CI checks pass