### PR TITLE
Add combo multiplier system for rapid ticket fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,7 @@
           <div class="card">
             <div class="k" data-i18n="lbl.score">Score</div>
             <div class="v mono" id="score">0</div>
+            <span id="comboIndicator" class="pill" hidden style="font-size:11px; border-color:rgba(255,183,77,.6); color:rgba(255,183,77,.95);">COMBO x1</span>
             <div class="small" data-i18n="hint.score">Deterministic per seed</div>
           </div>
           <div class="card">

--- a/src/main.ts
+++ b/src/main.ts
@@ -197,6 +197,9 @@ type UIRefs = {
   sparkJank: HTMLElement;
   sparkHeap: HTMLElement;
 
+  // Combo
+  comboIndicator: HTMLElement;
+
   // Challenges
   challengeDaily: HTMLElement;
   challengeWeekly: HTMLElement;
@@ -1508,6 +1511,10 @@ function syncUI() {
   setText(refs.rating, `${s.rating.toFixed(1)} ★`);
   setText(refs.seedVal, `${s.seed}`);
   setText(refs.score, `${Math.round(s.score)}`);
+  refs.comboIndicator.hidden = !s.comboActive;
+  if (s.comboActive) {
+    refs.comboIndicator.textContent = `COMBO x${s.comboCount}`;
+  }
   setText(refs.archDebt, `${Math.round(s.architectureDebt)}`);
   setText(refs.fail, `${(s.failureRate * 100).toFixed(1)}%`);
   setText(refs.anr, `${(s.anrRisk * 100).toFixed(1)}%`);
@@ -1791,6 +1798,8 @@ function bindUI(): UIRefs {
     sparkFail: must('sparkFail'),
     sparkJank: must('sparkJank'),
     sparkHeap: must('sparkHeap'),
+
+    comboIndicator: must('comboIndicator'),
 
     challengeDaily: must('challengeDaily'),
     challengeWeekly: must('challengeWeekly'),

--- a/src/sim.ts
+++ b/src/sim.ts
@@ -216,6 +216,13 @@ export class GameSim {
   private lastEventAt = 0;
   private incidentCount = 0;
   private recentIncidentTimes: number[] = [];
+
+  // Combo system: track recent ticket fix times for combo multiplier.
+  private recentFixTimes: number[] = [];
+  comboActive = false;
+  comboCount = 0;
+  comboUntil = 0;
+  comboBonusAccum = 0;
   private eventLines: string[] = [];
   private eventStream: SimEvent[] = [];
 
@@ -322,6 +329,11 @@ export class GameSim {
     this.lastEventAt = 0;
     this.incidentCount = 0;
     this.recentIncidentTimes = [];
+    this.recentFixTimes = [];
+    this.comboActive = false;
+    this.comboCount = 0;
+    this.comboUntil = 0;
+    this.comboBonusAccum = 0;
     this.eventLines = [];
 
     this.queues.clear();
@@ -537,6 +549,15 @@ export class GameSim {
     this.tickets = this.tickets.filter(x => x.id !== id);
     this.addEvent(`Fixed ticket: ${t.title}`);
     this.eventStream.push({ type: 'TICKET_FIXED', atSec: this.timeSec, kind: t.kind, effort: t.effort });
+
+    // Combo tracking: 3 fixes within 60s triggers a combo.
+    this.recentFixTimes = this.recentFixTimes.filter(ft => this.timeSec - ft < 60);
+    this.recentFixTimes.push(this.timeSec);
+    if (this.recentFixTimes.length >= 3 && !this.comboActive) {
+      this.comboActive = true;
+      this.comboCount++;
+      this.comboUntil = this.timeSec + 30;
+    }
   }
 
   deferTicket(id: number) {
@@ -1435,7 +1456,14 @@ private tickCoverageGate() {
     this.battery = clamp(this.battery + (this.running ? 0.06 : 0.12), 0, 100);
 
     // Score: accumulate per tick while the run is alive.
-    this.score += this.calcTickScore(failureRate, anrRisk, p95);
+    // Combo multiplier: +20% score per tick while combo is active.
+    if (this.comboActive && this.timeSec > this.comboUntil) {
+      this.comboActive = false;
+    }
+    const comboMul = this.comboActive ? 1.20 : 1.0;
+    const tickScore = this.calcTickScore(failureRate, anrRisk, p95) * comboMul;
+    if (this.comboActive) this.comboBonusAccum += tickScore - this.calcTickScore(failureRate, anrRisk, p95);
+    this.score += tickScore;
 
     // Shift complete: end the run in the target 8–10 minute window (per preset).
     // Only applies to active runs so unit tests that call tick() directly remain deterministic.
@@ -1502,7 +1530,11 @@ private tickCoverageGate() {
         canDelete: true
       } : undefined,
 
-      eventsText: this.eventLines.length ? this.eventLines.join('\n') : 'No incidents… yet.'
+      eventsText: this.eventLines.length ? this.eventLines.join('\n') : 'No incidents… yet.',
+
+      comboActive: this.comboActive,
+      comboCount: this.comboCount,
+      comboUntilSec: this.comboUntil,
     };
   }
 


### PR DESCRIPTION
## Summary

Closes #38.

Adds a combo system that rewards tactical ticket fixing:

### Combo mechanics
- Fix 3 tickets within 60 seconds to trigger a combo
- While combo is active (30 seconds), score per tick is boosted by +20%
- A "COMBO x1" indicator appears next to the score display
- Multiple combos stack the counter (COMBO x1, x2, x3...)

### Tracking
- `recentFixTimes` tracks ticket fix timestamps (rolling 60s window)
- `comboActive`, `comboCount`, `comboUntil` exposed in UI state
- `comboBonusAccum` tracks total bonus score earned from combos
- All combo state resets on game reset

### UI
- Orange pill indicator next to the score card, shown only while combo is active
- Hidden when no combo

## Test plan

- [x] `npm run build` - clean compile
- [x] `npm run test:unit` - 37/37 pass
- [x] `npm run test:dom` - 119 DOM IDs validated (+1 comboIndicator)
- [x] `npm run test:e2e:ci` - 7/7 E2E tests pass
- [x] CI checks pass