### PR TITLE
Clear scoreboard-origin tamper flag when user clicks Clear

### DIFF
--- a/src/integrity.ts
+++ b/src/integrity.ts
@@ -17,6 +17,21 @@ export function markTampered(reason: string): void {
   for (const cb of listeners) cb();
 }
 
+/**
+ * Clear the tamper flag if its current reason matches one of the given reasons.
+ * Used when the user takes an action that resolves the underlying cause
+ * (e.g. Clear Scoreboard resolves 'scoreboard' and 'score' reasons).
+ * No-op if untampered or if the reason does not match.
+ */
+export function clearTamperIf(reasons: string | string[]): void {
+  if (!tampered) return;
+  const list = Array.isArray(reasons) ? reasons : [reasons];
+  if (tamperReason !== null && list.includes(tamperReason)) {
+    tampered = false;
+    tamperReason = null;
+  }
+}
+
 export function getTamperState(): { tampered: boolean; reason: string | null } {
   return { tampered, reason: tamperReason };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { GameSim } from './sim';
 import { AchievementsTracker, LocalStorageAchStorage, AchEvent, AchievementUnlock } from './achievements';
 import { addScoreEntry, clearScoreboard, loadScoreboard, sealScoreboard, verifyScoreboard } from './scoreboard';
 import { MODE, Mode, ComponentType, Ticket, EvalPreset, EVAL_PRESET, RefactorAction } from './types';
-import { deriveKey, sealStorageKey, verifyStorageKey, markTampered, getTamperState, isScoreSane, needsMigration, setMigrationDone } from './integrity';
+import { deriveKey, sealStorageKey, verifyStorageKey, markTampered, getTamperState, clearTamperIf, isScoreSane, needsMigration, setMigrationDone } from './integrity';
 import './entropy';
 import { Sparkline } from './sparkline';
 import { getDailyChallenge, getWeeklyChallenge, evaluateChallenge, saveChallengeResult, loadChallengeResults, type ChallengeDef } from './challenges';
@@ -1366,6 +1366,10 @@ refs.btnCopyRun.onclick = async () => {
 refs.btnClearScoreboard.onclick = () => {
   clearScoreboard();
   integrityKeyPromise.then(key => sealScoreboard(key));
+  // Clearing the scoreboard resolves scoreboard-origin tamper reasons. Other
+  // reasons (achievements, runtime) stay sticky since their data is untouched.
+  clearTamperIf(['scoreboard', 'score']);
+  refs.integrityBadge.hidden = !getTamperState().tampered;
   renderScoreboard();
   toast(t('toast.scoreboardCleared'));
 };

--- a/tests/unit/integrity.test.ts
+++ b/tests/unit/integrity.test.ts
@@ -6,6 +6,7 @@ import {
   markTampered,
   getTamperState,
   onTamperDetected,
+  clearTamperIf,
   isScoreSane,
   _resetForTest,
 } from '../../src/integrity';
@@ -74,6 +75,31 @@ describe('tamper flag', () => {
     onTamperDetected(() => { called = true; });
     markTampered('test');
     expect(called).toBe(true);
+  });
+
+  it('clearTamperIf clears when reason matches', () => {
+    markTampered('scoreboard');
+    clearTamperIf('scoreboard');
+    expect(getTamperState().tampered).toBe(false);
+    expect(getTamperState().reason).toBeNull();
+  });
+
+  it('clearTamperIf is a no-op when reason does not match', () => {
+    markTampered('runtime');
+    clearTamperIf(['scoreboard', 'score']);
+    expect(getTamperState().tampered).toBe(true);
+    expect(getTamperState().reason).toBe('runtime');
+  });
+
+  it('clearTamperIf accepts an array of reasons', () => {
+    markTampered('score');
+    clearTamperIf(['scoreboard', 'score']);
+    expect(getTamperState().tampered).toBe(false);
+  });
+
+  it('clearTamperIf is a no-op when untampered', () => {
+    clearTamperIf('scoreboard');
+    expect(getTamperState().tampered).toBe(false);
   });
 });
 


### PR DESCRIPTION
The "⚠ Tampered" badge on the scoreboard card was sticky for the whole session even after the user clicked Clear. The tamper flag is a module-level singleton in src/integrity.ts that was only set, never conditionally cleared. Clear Scoreboard wiped the storage and re-sealed, but the flag stayed true, so the badge only disappeared on a full page reload.

Scoreboard-origin tamper reasons ('scoreboard' from verifyScoreboard failing on load, 'score' from isScoreSane rejecting a final score) are resolved by wiping the scoreboard. Other reasons ('achievements', 'runtime') point at data the Clear button does not touch and must stay sticky.

- Add clearTamperIf(reasons) to src/integrity.ts that clears the flag only when the stored reason matches one of the given reasons.
- Wire the Clear Scoreboard handler in src/main.ts to call clearTamperIf(['scoreboard', 'score']) and refresh the badge synchronously.
- Add 4 unit tests covering match, non-match, array input, and untampered no-op.