### PR TITLE
Add action log + replay verification to every run

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ More details: see docs/GAMEPLAY.md and docs/SCENARIOS.md
 
 - Gameplay (seeds, scoring, incidents, postmortems, profile & achievements): [GAMEPLAY.md](./docs/GAMEPLAY.md)
 - Scenarios (Release Trains launch drills): [SCENARIOS.md](./docs/SCENARIOS.md)
+- Roadmap (Phase 2 Cloudflare Worker scoreboard, Phase 3 hardening): [ROADMAP.md](./docs/ROADMAP.md)
 - Systems (concepts + realism layers): [SYSTEMS.md](./docs/SYSTEMS.md)
 - Architecture rules and refactor roadmap: [ARCHITECTURE_RULES.md](./docs/ARCHITECTURE_RULES.md)
 - Evaluation exercise + level differentiation lens: [EVALUATION.md](./docs/EVALUATION.md)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,107 @@
+# Roadmap
+
+Intentionally small. Phase 1 shipped in v0.4 (action log + client-side replay
+verification on each run end). The next two phases take the same log format
+and move the trust boundary server-side.
+
+## Phase 2: Cloudflare Worker scoreboard
+
+**Goal:** a public, per-preset leaderboard where every entry has been
+replay-verified on infrastructure the client cannot tamper with.
+
+**Why now:** the action log format is already stable in v0.4, and every run in
+`asr:runs:v1` contains exactly what the Worker needs. We are not re-deriving
+the wire format; we are shipping the storage format directly.
+
+**Shape:**
+
+```
+POST /run
+  body: { seed, preset, actionLog, claimedScore, claimedRating, clientVersion }
+  server:
+    - re-runs replayActionLog() against a fresh GameSim on the Worker runtime
+    - compares simScore to claimedScore
+    - rejects if mismatch > epsilon
+    - writes to KV keyed by preset + score (sorted)
+
+GET /leaderboard?preset=SENIOR&limit=50
+  server: returns top N from KV
+```
+
+**Infra (all free tier):**
+
+- Cloudflare Workers: 100k requests/day, 10ms CPU/request.
+- Cloudflare KV: 1GB storage, 100k reads/day, 1k writes/day.
+- Deploy via Wrangler CLI or a GitHub Actions workflow on push to `main`.
+
+**Implementation notes:**
+
+- The Worker imports `src/sim.ts`, `src/subsystems.ts`, `src/actionlog.ts`
+  unchanged. No code duplication. One source of truth for simulation rules.
+- No `localStorage` or DOM access in those modules (they're already pure).
+  Minor: `applyReward` calls `sim.budget +=` which is safe in Workers.
+- Keep the Worker stateless beyond KV. No sessions, no auth in Phase 2.
+  Anonymous submissions with the score attached, Worker validates.
+- Rate limit per IP on `POST /run`. Workers provides `cf.clientTcpRtt` and
+  colo metadata natively; simple in-memory bucket per IP per Worker instance
+  is enough for v1 (a determined attacker bypasses it, but the price of
+  submitting a forged log is still running the real sim to produce valid
+  rand sequences).
+
+**Client changes:**
+
+- Add a "Submit to leaderboard" button on the end-of-run modal, behind an
+  opt-in (disabled by default, so offline-only players aren't surprised).
+- New local setting `asr:submit-enabled:v1`.
+- A `LeaderboardCard` next to the existing local scoreboard.
+
+**Out of scope for Phase 2:**
+
+- Accounts / auth. Anonymous-only leaderboard.
+- Anti-duplicate-submission.
+- Historical browsing beyond top-N.
+
+## Phase 3: Hardening
+
+Once Phase 2 is live, the attack surface shifts from "edit localStorage" to
+"craft a valid action log that replays to a high score". That's genuinely
+harder — the attacker has to produce a sequence of game-legal moves — but not
+impossible. Phase 3 closes the remaining gaps.
+
+### 3.1 Replay protection
+
+- Generate a per-session client token on first run (HMAC of `seed + startTs`
+  signed with a public constant). Embed it in every submission.
+- Worker rejects duplicate `(seed, clientToken)` pairs. Forces a new session
+  to replay a given scripted timeline.
+
+### 3.2 Rate limiting and anomaly flags
+
+- Per-IP hard cap on POST /run (e.g. 60 per hour).
+- Per-seed soft cap (e.g. 10 unique clients, flag the 11th).
+- Flag submissions where the replayed timeline contains impossibly fast
+  action sequences (e.g. 30 actions in tick 0). Note: this is a signal, not
+  a block — legit speed runs cluster actions at t=0.
+
+### 3.3 Audit log
+
+- Every accepted submission writes an audit row to a second KV namespace:
+  `{ seed, claimedScore, ip_hash, userAgent_hash, acceptedAt }`.
+- Public dashboard (read-only) for researchers.
+- 90-day retention.
+
+### 3.4 Known limitations (never closed)
+
+- A sufficiently motivated attacker can still run the full sim offline to
+  produce legal action logs optimized for score, then submit. The game is
+  small; this will happen. The defense is client entertainment, not
+  anti-cheat rigor. If leaderboard integrity ever matters more, the real
+  fix is moving sim execution server-side (player submits *actions* to the
+  Worker in real time and the Worker owns the only GameSim instance).
+
+## Not planned
+
+- Accounts, OAuth, Firebase.
+- Realtime multiplayer.
+- Server-side sim execution (too expensive; see "Known limitations" above).
+- NFT / token anything.

--- a/index.html
+++ b/index.html
@@ -442,6 +442,7 @@
           <div><div class="k">Tickets</div><div class="mono" id="endRunTickets">-</div></div>
         </div>
         <div id="endRunBonuses" class="small" style="margin-top:var(--space-3);"></div>
+        <div id="endRunVerified" class="small mono" style="margin-top:var(--space-3);"></div>
         <div class="row" style="margin-top:var(--space-4); justify-content:center;">
           <button id="endRunPlayAgain" class="btn filled">Play Again</button>
           <button id="endRunReplay" class="btn outlined">Replay Seed</button>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:watch": "node ./node_modules/vitest/dist/cli.js",
     "test:e2e": "playwright test",
     "test:e2e:ci": "npm run test:dom && playwright test",
-    "test:dom": "node scripts/validate-dom-hooks.mjs"
+    "test:dom": "node scripts/validate-dom-hooks.mjs",
+    "test:clean": "pkill -f 'app-survival-android/node_modules/vitest' || true"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/src/actionlog.ts
+++ b/src/actionlog.ts
@@ -1,0 +1,128 @@
+/**
+ * Action log + deterministic replay.
+ *
+ * Every public mutator on GameSim records an ActionLogEntry. Given the same
+ * seed + preset + ordered log, a fresh sim re-runs identically and produces
+ * the same sim-side score. This is the core of v0.4 replay verification and
+ * the data format that future server-side validation (Phase 2) will consume.
+ */
+
+import { GameSim } from './sim';
+import type { EvalPreset, ComponentType, RefactorAction } from './types';
+
+export type ActionLogEntry = {
+  /** Sim-side clock (seconds) when the action was recorded. */
+  t: number;
+  /** Monotonic sequence number within a single tick, for stable ordering. */
+  seq: number;
+  /** Discriminator. Matches the sim method name the action applies to. */
+  kind: string;
+  /** JSON-serializable args for the action. */
+  args: unknown[];
+};
+
+export type ReplayInput = {
+  seed: number;
+  preset: EvalPreset;
+  log: ActionLogEntry[];
+  bounds: { width: number; height: number };
+  /**
+   * Optional: the tick count to stop replay at. When set, replay halts once
+   * `sim.timeSec >= untilTimeSec`. Required for verifying a live run that
+   * paused or otherwise stopped before endRun fired; otherwise replay runs
+   * until endRun triggers at shift end, producing a different score than
+   * the truncated live run.
+   */
+  untilTimeSec?: number;
+};
+
+export type ReplayResult = {
+  simScore: number;
+  rating: number;
+  durationSec: number;
+  timeSec: number;
+};
+
+/**
+ * Re-runs a sim from scratch using the provided action log. Pure replay:
+ * no network, no localStorage, no achievement rewards beyond what the log
+ * records. Callers compare `simScore` to the live run's sim-side score.
+ */
+export function replayActionLog(input: ReplayInput): ReplayResult {
+  const sim: any = new GameSim();
+  sim.setPreset(input.preset);
+  sim.reset(input.bounds, { seed: input.seed });
+  // Suppress re-logging while we replay actions, otherwise the replayed
+  // sim's actionLog would grow during verification.
+  sim.suppressActionLog = true;
+
+  // Stable ordering: by tick, then by seq within a tick.
+  const ordered = input.log.slice().sort((a, b) => (a.t - b.t) || (a.seq - b.seq));
+
+  let cursor = 0;
+  const MAX_TICKS = 20000; // guard against pathological logs hanging CI
+  let ticks = 0;
+  while (ticks < MAX_TICKS) {
+    // Apply every action scheduled for this exact tick (in seq order).
+    while (cursor < ordered.length && ordered[cursor].t === sim.timeSec) {
+      applyAction(sim, ordered[cursor]);
+      cursor++;
+    }
+
+    if (input.untilTimeSec !== undefined) {
+      // When untilTimeSec is set, it's the sole stop signal: tick all the way
+      // to that tick even if the sim has already ended mid-replay, since the
+      // live run may have ticked past endRun too (the caller's for-loop
+      // doesn't necessarily halt on running=false).
+      if (sim.timeSec >= input.untilTimeSec) break;
+    } else if (cursor >= ordered.length && (sim.lastRun || !sim.running)) {
+      // No hard cap: stop when the log is exhausted and the sim has ended.
+      break;
+    }
+
+    sim.tick();
+    ticks++;
+  }
+
+  return {
+    simScore: sim.score,
+    rating: sim.rating,
+    durationSec: Math.floor(sim.timeSec),
+    timeSec: sim.timeSec,
+  };
+}
+
+function applyAction(sim: any, entry: ActionLogEntry): void {
+  switch (entry.kind) {
+    case 'setPreset':               sim.setPreset(entry.args[0] as EvalPreset); break;
+    case 'setRunning':              sim.setRunning(entry.args[0] as boolean); break;
+    case 'setSelected':             sim.setSelected(entry.args[0] as number | null); break;
+    case 'applyReward':             sim.applyReward(entry.args[0] as number, entry.args[1] as number); break;
+    case 'addComponent':            sim.addComponent(entry.args[0] as ComponentType, entry.args[1] as number, entry.args[2] as number); break;
+    case 'upgradeSelected':         sim.upgradeSelected(); break;
+    case 'repairSelected':          sim.repairSelected(); break;
+    case 'deleteSelected':          sim.deleteSelected(); break;
+    case 'link':                    sim.link(entry.args[0] as number, entry.args[1] as number); break;
+    case 'unlink':                  sim.unlink(entry.args[0] as number, entry.args[1] as number); break;
+    case 'fixTicket':               sim.fixTicket(entry.args[0] as number); break;
+    case 'deferTicket':             sim.deferTicket(entry.args[0] as number); break;
+    case 'applyRefactor':           sim.applyRefactor(entry.args[0] as number, entry.args[1] as RefactorAction, entry.args[2] as string | undefined); break;
+    case 'buyCapacityRefill':       sim.buyCapacityRefill(); break;
+    case 'buyCapacityRegenUpgrade': sim.buyCapacityRegenUpgrade(); break;
+    case 'hireMoreCapacity':        sim.hireMoreCapacity(); break;
+    case 'buyRegenBooster':         sim.buyRegenBooster(); break;
+    case 'buyIncidentShield':       sim.buyIncidentShield(); break;
+    case 'buyBaselineProfile':      sim.buyBaselineProfile(); break;
+    case 'buyR8':                   sim.buyR8(); break;
+    case 'buyBundleSplit':          sim.buyBundleSplit(); break;
+    case 'loadScenario':
+      // Replay shouldn't re-reset the sim (that would wipe our in-progress
+      // state). Just restore the scenario metadata and scripted incidents.
+      sim.scenarioId = entry.args[0] as string;
+      sim.scriptedIncidents = new Map(entry.args[3] as Array<[number, string]>);
+      break;
+    default:
+      // Unknown kinds are silently ignored so the log format can evolve.
+      break;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -234,6 +234,9 @@ type UIRefs = {
   // End-of-run grade (v0.3.0)
   endRunGrade: HTMLElement;
   endRunGradeCallouts: HTMLElement;
+
+  // End-of-run replay verification (v0.4)
+  endRunVerified: HTMLElement;
 };
 
 
@@ -280,6 +283,23 @@ let lastSavedRunId: string | null = null;
 // --- Integrity (tamper protection v1) -------------------------------------
 const ACH_PREFIX = 'survival.achievements.';
 const integrityKeyPromise = deriveKey(sha);
+
+// Per-run action log archive. Keyed by runId, capped at RUNS_MAX entries so
+// the scoreboard card stays small and future Phase 2 submissions have a
+// well-defined history to read from.
+const RUNS_KEY = 'asr:runs:v1';
+const RUNS_MAX = 20;
+
+function persistRunActionLog(runId: string, seed: number, preset: string, log: ReadonlyArray<unknown>): void {
+  try {
+    const raw = localStorage.getItem(RUNS_KEY);
+    const existing: Array<{ runId: string }> = raw ? (JSON.parse(raw) || []) : [];
+    const next = [{ runId, seed, preset, savedAt: Date.now(), log }, ...existing.filter(e => e.runId !== runId)].slice(0, RUNS_MAX);
+    localStorage.setItem(RUNS_KEY, JSON.stringify(next));
+  } catch {
+    // private browsing / quota — ignore
+  }
+}
 
 integrityKeyPromise.then(async (key) => {
   if (needsMigration()) {
@@ -649,8 +669,11 @@ function formatReward(r?: { budget?: number; score?: number }): string {
 function applyAchievementRewards(unlocked: AchievementUnlock[]) {
   if (!unlocked.length) return;
   for (const a of unlocked) {
-    if (a.reward?.budget) sim.budget += a.reward.budget;
-    if (a.reward?.score) sim.score += a.reward.score;
+    // Route through sim.applyReward so the mutation lands in the action log
+    // and replay verification reproduces the same score.
+    const b = a.reward?.budget ?? 0;
+    const s = a.reward?.score ?? 0;
+    if (b !== 0 || s !== 0) sim.applyReward(b, s);
     const reward = formatReward(a.reward);
     const tier = a.label ? ` ${a.label}` : '';
     const rewardSuffix = reward ? ` (${reward})` : '';
@@ -1025,19 +1048,19 @@ refs.btnStart.onclick = () => {
   achLastTickSec = -1;
   applyAchievementRewards(ach.onEvents([{ type: 'RUN_START', atSec: sim.timeSec, budget: sim.budget, architectureDebt: sim.architectureDebt }]));
   integrityKeyPromise.then(key => sealStorageKey(ACH_PREFIX + preset, key));
-  sim.running = true;
+  sim.setRunning(true);
   startTickLoop();
   syncUI();
 };
 refs.btnPause.onclick = () => {
-  sim.running = false;
+  sim.setRunning(false);
   syncUI();
 };
 refs.btnReset.onclick = () => {
   // Treat reset as run end for achievements tracking.
   applyAchievementRewards(ach.onEvents([{ type: 'RUN_END', atSec: sim.timeSec, reason: 'RESET' }]));
   integrityKeyPromise.then(key => sealStorageKey(ACH_PREFIX + (refs.presetSelect.value as EvalPreset), key));
-  sim.running = false;
+  sim.setRunning(false);
   achLastTickSec = -1;
   const seedStr = (refs.seedInput.value ?? '').trim();
   const seed = seedStr ? Number(seedStr) : undefined;
@@ -1057,7 +1080,7 @@ refs.btnDailySeed.onclick = () => {
   const day = d.getUTCDate();
   const daily = (y * 10000 + m * 100 + day) >>> 0;
   refs.seedInput.value = String(daily);
-  sim.running = false;
+  sim.setRunning(false);
   sim.reset(getCanvasBounds(), { seed: daily });
   fitToView();
   syncUI();
@@ -1084,14 +1107,16 @@ function renderChallenges() {
 
 function startChallenge(challenge: ChallengeDef) {
   activeChallenge = challenge;
-  sim.running = false;
+  sim.setRunning(false);
   refs.presetSelect.value = challenge.preset;
   sim.setPreset(challenge.preset);
   ach.setPreset(challenge.preset);
   refs.seedInput.value = String(challenge.seed);
   sim.reset(getCanvasBounds(), { seed: challenge.seed });
   if (challenge.constraint === 'LOW_BUDGET') {
-    sim.budget = 1500;
+    // LOW_BUDGET drops the default starting budget to $1500. Route through
+    // applyReward so replay reproduces the same delta and verification passes.
+    sim.applyReward(1500 - sim.budget, 0);
   }
   sparkRating.reset(); sparkFail.reset(); sparkJank.reset(); sparkHeap.reset();
   fitToView();
@@ -1138,7 +1163,7 @@ function renderScenarios() {
 
 function startScenario(scenario: ScenarioDef) {
   activeScenario = scenario;
-  sim.running = false;
+  sim.setRunning(false);
   refs.presetSelect.value = scenario.preset;
   ach.setPreset(scenario.preset);
   sim.loadScenario(
@@ -1148,7 +1173,7 @@ function startScenario(scenario: ScenarioDef) {
   refs.seedInput.value = String(scenario.seed);
   sparkRating.reset(); sparkFail.reset(); sparkJank.reset(); sparkHeap.reset();
   fitToView();
-  sim.running = true;
+  sim.setRunning(true);
   syncUI();
 }
 
@@ -1225,6 +1250,19 @@ function showEndRunModal() {
     refs.endRunGradeCallouts.textContent = '';
   }
 
+  // Replay verification badge (v0.4)
+  if (run.verified === true) {
+    refs.endRunVerified.textContent = '✓ Verified (replay matches)';
+    refs.endRunVerified.classList.remove('is-failure');
+    refs.endRunVerified.classList.add('is-success');
+  } else if (run.verified === false) {
+    refs.endRunVerified.textContent = '✗ Replay mismatch';
+    refs.endRunVerified.classList.remove('is-success');
+    refs.endRunVerified.classList.add('is-failure');
+  } else {
+    refs.endRunVerified.textContent = '';
+  }
+
   openModal(refs.endRunModal);
 }
 
@@ -1237,7 +1275,7 @@ refs.endRunBackdrop.onclick = closeEndRun;
 
 refs.endRunPlayAgain.onclick = () => {
   closeEndRun();
-  sim.running = false;
+  sim.setRunning(false);
   sim.reset(getCanvasBounds());
   sparkRating.reset(); sparkFail.reset(); sparkJank.reset(); sparkHeap.reset();
   fitToView();
@@ -1247,7 +1285,7 @@ refs.endRunPlayAgain.onclick = () => {
 refs.endRunReplay.onclick = () => {
   closeEndRun();
   const seed = sim.lastRun?.seed;
-  sim.running = false;
+  sim.setRunning(false);
   sim.reset(getCanvasBounds(), seed ? { seed } : undefined);
   if (seed) refs.seedInput.value = String(seed);
   sparkRating.reset(); sparkFail.reset(); sparkJank.reset(); sparkHeap.reset();
@@ -1446,14 +1484,14 @@ refs.canvas.addEventListener('mousedown', (e) => {
   const hit = hitComponent(pt.x, pt.y);
 
   if (!hit) {
-    sim.selectedId = null;
+    sim.setSelected(null);
     sim.linkFromId = null;
     syncUI();
     return;
   }
 
   if (sim.mode === MODE.SELECT) {
-    sim.selectedId = hit.id;
+    sim.setSelected(hit.id);
     draggingId = hit.id;
     dragOffX = pt.x - hit.x;
     dragOffY = pt.y - hit.y;
@@ -1465,7 +1503,7 @@ refs.canvas.addEventListener('mousedown', (e) => {
   // Link/Unlink
   if (!sim.linkFromId) {
     sim.linkFromId = hit.id;
-    sim.selectedId = hit.id;
+    sim.setSelected(hit.id);
     syncUI();
     return;
   }
@@ -1922,6 +1960,7 @@ function syncUI() {
       });
       integrityKeyPromise.then(key => sealScoreboard(key));
       renderScoreboard();
+      persistRunActionLog(s.lastRun.runId, s.lastRun.seed, s.lastRun.preset, sim.getActionLog());
 
       // Evaluate active challenge
       if (activeChallenge && s.lastRun.seed === activeChallenge.seed) {
@@ -2180,6 +2219,7 @@ function bindUI(): UIRefs {
     scenarioList: must('scenarioList'),
     endRunGrade: must('endRunGrade'),
     endRunGradeCallouts: must('endRunGradeCallouts'),
+    endRunVerified: must('endRunVerified'),
   };
 }
 

--- a/src/sim.ts
+++ b/src/sim.ts
@@ -27,6 +27,7 @@ import { entropyPool } from './entropy';
 import { tickPlatformPulse as platformPulseTick, tickCoverageGate as coverageGateTick, computeRegionTarget, evaluateCrossCheck, tickRolloutPhase, applyRegionCoupling, tickBaselineProfile, tickPlayIntegrity, type CoverageGateInput, type CrossCheckInput, type RolloutPhase } from './subsystems';
 import { tickBurnout } from './oncall';
 import { gradePostmortem, type PostmortemGrade } from './postmortem';
+import { replayActionLog } from './actionlog';
 
 export const ComponentDefs: Record<ComponentType, ComponentDef> = {
   // Core layers (Android mental model, not backend microservices)
@@ -281,6 +282,46 @@ export class GameSim {
   /** Full retained event log for the current run (used for postmortem grading). */
   private runEventLog: SimEvent[] = [];
 
+  /**
+   * Per-run action log. Every public mutator appends here so a fresh sim can
+   * replay the run deterministically (see src/actionlog.ts). Cleared on reset().
+   */
+  private actionLog: Array<{ t: number; seq: number; kind: string; args: unknown[] }> = [];
+  private actionSeq: number = 0;
+  /** When true (set by the replayer), public mutators skip recording. */
+  suppressActionLog: boolean = false;
+
+  private recordAction(kind: string, args: unknown[]): void {
+    if (this.suppressActionLog) return;
+    this.actionLog.push({ t: this.timeSec, seq: this.actionSeq++, kind, args });
+  }
+
+  /** Read-only snapshot of the current run's action log. */
+  getActionLog(): ReadonlyArray<{ t: number; seq: number; kind: string; args: unknown[] }> {
+    return this.actionLog;
+  }
+
+  /** Sets the currently selected component id. Routes direct field mutation through a logged entry. */
+  setSelected(id: number | null): void {
+    if (this.selectedId === id) return;
+    this.recordAction('setSelected', [id]);
+    this.selectedId = id;
+  }
+
+  /** Sets the run's running flag. Routes direct field mutation through a logged entry. */
+  setRunning(b: boolean): void {
+    if (this.running === b) return;
+    this.recordAction('setRunning', [b]);
+    this.running = b;
+  }
+
+  /** Applies an external reward (budget + score delta), typically from an achievement unlock. */
+  applyReward(budgetDelta: number, scoreDelta: number): void {
+    this.recordAction('applyReward', [budgetDelta, scoreDelta]);
+    this.budget += budgetDelta;
+    this.score += scoreDelta;
+  }
+
   private queues = new Map<number, Request[]>();
 
   reset(bounds: Bounds, opts?: { seed?: number }) {
@@ -322,6 +363,11 @@ export class GameSim {
     // Scenario state is reset-by-default; callers can re-apply loadScenario() after.
     this.scenarioId = null;
     this.scriptedIncidents.clear();
+
+    // Action log is per-run: reset erases prior actions so the log reflects only
+    // the upcoming run. The seed itself is implicit in the run's ReplayInput.
+    this.actionLog = [];
+    this.actionSeq = 0;
 
     // ZeroDayPulse
     this.advisories = [];
@@ -420,6 +466,10 @@ export class GameSim {
 
     this.components.push(nUI, nVM, nD, nR, nC, nDB, nN, nW, nO, nF);
 
+    // Starter layout: these are part of the reset's initial state, not user
+    // actions. Suppress recording so the action log only contains player input.
+    const wasSuppressed = this.suppressActionLog;
+    this.suppressActionLog = true;
     this.link(nUI.id, nVM.id);
     this.link(nVM.id, nD.id);
     this.link(nD.id,  nR.id);
@@ -427,6 +477,7 @@ export class GameSim {
     this.link(nC.id,  nDB.id);
     this.link(nR.id,  nN.id);
     this.link(nW.id,  nR.id);
+    this.suppressActionLog = wasSuppressed;
 
     this.selectedId = nR.id;
   }
@@ -478,6 +529,7 @@ export class GameSim {
   }
 
   buyCapacityRefill(): { ok: boolean; reason?: string } {
+    this.recordAction('buyCapacityRefill', []);
     const { refillCost } = this.getCapacityShop();
     if (this.engCapacity >= this.engCapacityMax - 1e-6) return { ok: false, reason: 'Capacity already full' };
     if (this.budget < refillCost) return { ok: false, reason: 'Not enough budget' };
@@ -490,6 +542,7 @@ export class GameSim {
   }
 
   buyCapacityRegenUpgrade(): { ok: boolean; reason?: string } {
+    this.recordAction('buyCapacityRegenUpgrade', []);
     const { regenUpgradeCost } = this.getCapacityShop();
     if (this.engRegenTier >= 3) return { ok: false, reason: 'Regen already maxed' };
     if (this.budget < regenUpgradeCost) return { ok: false, reason: 'Not enough budget' };
@@ -501,6 +554,7 @@ export class GameSim {
   }
 
   hireMoreCapacity(): { ok: boolean; reason?: string } {
+    this.recordAction('hireMoreCapacity', []);
     const { hireCost } = this.getCapacityShop();
     if (this.engCapacityMax >= 30) return { ok: false, reason: 'Capacity already at max' };
     if (this.budget < hireCost) return { ok: false, reason: 'Not enough budget' };
@@ -514,6 +568,7 @@ export class GameSim {
   }
 
   buyRegenBooster(): { ok: boolean; reason?: string } {
+    this.recordAction('buyRegenBooster', []);
     const { boosterCost, canBuyBooster } = this.getCapacityShop();
     if (!canBuyBooster) return { ok: false, reason: 'Booster already active' };
     if (this.budget < boosterCost) return { ok: false, reason: 'Not enough budget' };
@@ -527,6 +582,7 @@ export class GameSim {
   }
 
   buyIncidentShield(): { ok: boolean; reason?: string } {
+    this.recordAction('buyIncidentShield', []);
     const { shieldCost, canBuyShield } = this.getCapacityShop();
     if (!canBuyShield) return { ok: false, reason: 'Shield already ready' };
     if (this.budget < shieldCost) return { ok: false, reason: 'Not enough budget' };
@@ -539,6 +595,7 @@ export class GameSim {
 
   // v0.3.0 Android-native one-time build surfaces.
   buyBaselineProfile(): { ok: boolean; reason?: string } {
+    this.recordAction('buyBaselineProfile', []);
     if (this.baselineProfile) return { ok: false, reason: 'Already shipped' };
     if (this.budget < 250) return { ok: false, reason: 'Not enough budget' };
     this.budget -= 250;
@@ -548,6 +605,7 @@ export class GameSim {
   }
 
   buyR8(): { ok: boolean; reason?: string } {
+    this.recordAction('buyR8', []);
     if (this.r8Enabled) return { ok: false, reason: 'R8 already enabled' };
     if (this.budget < 200) return { ok: false, reason: 'Not enough budget' };
     this.budget -= 200;
@@ -557,6 +615,7 @@ export class GameSim {
   }
 
   buyBundleSplit(): { ok: boolean; reason?: string } {
+    this.recordAction('buyBundleSplit', []);
     if (this.bundleSplitEnabled) return { ok: false, reason: 'Bundle split already enabled' };
     if (this.budget < 180) return { ok: false, reason: 'Not enough budget' };
     this.budget -= 180;
@@ -600,6 +659,7 @@ export class GameSim {
   getRegPressure(): number { return this.regPressure; }
   getCoverage() { return { pct: this.coveragePct, threshold: this.coverageThreshold, preset: this.preset }; }
   setPreset(p: EvalPreset) {
+    this.recordAction('setPreset', [p]);
     this.preset = p;
     this.coverageThreshold =
       (p === EVAL_PRESET.PRINCIPAL) ? 80 :
@@ -622,6 +682,7 @@ export class GameSim {
   getAdvisories(): Advisory[] { return this.advisories; }
 
   fixTicket(id: number) {
+    this.recordAction('fixTicket', [id]);
     const t = this.tickets.find(x => x.id === id);
     if (!t) return;
     const cost = t.effort;
@@ -677,6 +738,7 @@ export class GameSim {
   }
 
   deferTicket(id: number) {
+    this.recordAction('deferTicket', [id]);
     const t = this.tickets.find(x => x.id === id);
     if (!t) return;
     t.deferred = !t.deferred;
@@ -684,6 +746,7 @@ export class GameSim {
 
   // --- public CRUD ----------------------------------------------------------
   addComponent(type: ComponentType, x: number, y: number): { ok: boolean; reason?: string; id?: number } {
+    this.recordAction('addComponent', [type, x, y]);
     const def = ComponentDefs[type];
     if (this.budget < def.cost) return { ok: false, reason: 'Not enough budget' };
     this.budget -= def.cost;
@@ -694,6 +757,7 @@ export class GameSim {
   }
 
   deleteSelected(): boolean {
+    this.recordAction('deleteSelected', []);
     const id = this.selectedId;
     if (!id) return false;
     this.links = this.links.filter(l => l.from !== id && l.to !== id);
@@ -705,6 +769,7 @@ export class GameSim {
   }
 
   upgradeSelected(): { ok: boolean; reason?: string } {
+    this.recordAction('upgradeSelected', []);
     const n = this.selected();
     if (!n) return { ok: false, reason: 'Nothing selected' };
     if (n.tier >= 3) return { ok: false, reason: 'Already max tier' };
@@ -717,6 +782,7 @@ export class GameSim {
   }
 
   repairSelected(): { ok: boolean; reason?: string } {
+    this.recordAction('repairSelected', []);
     const n = this.selected();
     if (!n) return { ok: false, reason: 'Nothing selected' };
     if (n.health >= 100 && !n.down) return { ok: false, reason: 'Already healthy' };
@@ -732,6 +798,7 @@ export class GameSim {
   setMode(m: Mode) { this.mode = m; this.linkFromId = null; }
 
   link(from: number, to: number): boolean {
+    this.recordAction('link', [from, to]);
     if (from === to) return false;
     if (this.links.some(l => l.from === from && l.to === to)) return false;
 
@@ -1025,6 +1092,7 @@ export class GameSim {
   }
 
   applyRefactor(ticketId: number, action: RefactorAction, targetKey?: string): { ok: boolean; reason?: string } {
+    this.recordAction('applyRefactor', [ticketId, action, targetKey]);
     const t = this.tickets.find(x => x.id === ticketId);
     if (!t) return { ok: false, reason: 'Ticket not found' };
     if (t.kind !== 'ARCHITECTURE_DEBT') return { ok: false, reason: 'Not an architecture debt ticket' };
@@ -1042,6 +1110,10 @@ export class GameSim {
     // Refactors improve quality process a bit (slows coverage decay etc.)
     this.qualityProcess = clamp(this.qualityProcess + 0.10, 0, 1);
 
+    // Internal unlink calls are a side effect of the refactor action; suppress
+    // their own recordAction so replay doesn't double-apply them.
+    const wasSuppressed = this.suppressActionLog;
+    this.suppressActionLog = true;
     switch (action) {
       case 'ADD_BOUNDARY': {
         if (targetKey && this.unlinkViolation(targetKey)) {
@@ -1080,6 +1152,7 @@ export class GameSim {
         break;
       }
     }
+    this.suppressActionLog = wasSuppressed;
 
     // Close the debt ticket (completed refactor).
     this.tickets = this.tickets.filter(x => x.id !== ticketId);
@@ -1090,6 +1163,7 @@ export class GameSim {
 
 
   unlink(from: number, to: number): boolean {
+    this.recordAction('unlink', [from, to]);
     const before = this.links.length;
     this.links = this.links.filter(l => !(l.from === from && l.to === to));
     return this.links.length !== before;
@@ -1171,6 +1245,14 @@ export class GameSim {
     for (const marker of scenario.incidentScript) {
       this.scriptedIncidents.set(marker.atSec, marker.kind);
     }
+    // Log after reset so the entry survives into the run's action log. Encode
+    // the scripted incident list so replay can reconstruct the same schedule.
+    this.recordAction('loadScenario', [
+      scenario.id,
+      scenario.seed,
+      scenario.preset,
+      scenario.incidentScript.map(m => [m.atSec, m.kind] as [number, IncidentKind]),
+    ]);
   }
 
   /** Returns the list of signals currently accumulating but not yet firing a ticket. */
@@ -2718,6 +2800,10 @@ private tickCoverageGate() {
   }
 
   private endRun(reason: EndReason, failureRate: number, anrRisk: number, p95: number) {
+    // endRun is idempotent per run: once lastRun exists, subsequent invocations
+    // (from post-terminal ticks re-checking rating/budget) are no-ops. Prevents
+    // redundant replay verification on every tick past the true end.
+    if (this.lastRun) return;
     this.running = false;
     this.eventStream.push({ type: 'RUN_END', atSec: this.timeSec, reason });
 
@@ -2788,6 +2874,29 @@ private tickCoverageGate() {
     this.lastRun.summaryLines.push(`Postmortem grade: ${grade.letter}`);
     for (const c of grade.callouts) this.lastRun.summaryLines.push(`- ${c}`);
     this.lastGrade = grade;
+
+    // Replay verification: run the action log against a fresh sim and compare
+    // sim-side score. Any mismatch points at tampered state or a missed
+    // recordAction hook. Skip when we're already inside a replay
+    // (suppressActionLog = true) to avoid infinite recursion, and when the
+    // run was never actually started (action log may be empty or minimal).
+    if (!this.suppressActionLog && this.actionLog.length > 0) {
+      try {
+        const liveSimScore = this.score;
+        const replayed = replayActionLog({
+          seed: this.seed,
+          preset: this.preset,
+          log: this.actionLog.slice(),
+          bounds: { width: 800, height: 600 },
+          untilTimeSec: this.timeSec,
+        });
+        // Accept small float drift (the sim has compounding multiplications).
+        const drift = Math.abs(replayed.simScore - liveSimScore);
+        this.lastRun.verified = drift < 1e-6;
+      } catch {
+        this.lastRun.verified = false;
+      }
+    }
 
     // Make the end visible in the on-screen log.
     this.log('RUN ENDED.');

--- a/src/types.ts
+++ b/src/types.ts
@@ -246,6 +246,14 @@ export type RunResult = {
 
   // Human-readable postmortem
   summaryLines: string[];
+
+  /**
+   * Whether a deterministic replay of this run's action log reproduced the
+   * live sim-side score. `true` = replay matched. `false` = mismatch (likely
+   * tampered state or dropped action). `undefined` on legacy runs scored
+   * before the action log was wired.
+   */
+  verified?: boolean;
 };
 
 

--- a/tests/unit/actionlog.test.ts
+++ b/tests/unit/actionlog.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { GameSim } from '../../src/sim';
+import { replayActionLog, type ActionLogEntry } from '../../src/actionlog';
+
+const BOUNDS = { width: 800, height: 600 };
+
+function runScripted(seed: number, ticks = 120, mutate?: (sim: any) => void): any {
+  const sim: any = new GameSim();
+  sim.setPreset('SENIOR');
+  sim.reset(BOUNDS, { seed });
+  if (mutate) mutate(sim);
+  sim.setRunning(true);
+  for (let i = 0; i < ticks; i++) sim.tick();
+  return sim;
+}
+
+describe('replayActionLog', () => {
+  it('two fresh sims replaying the same log produce the same simScore', () => {
+    const a = runScripted(12345, 180, (sim) => {
+      sim.setSelected(sim.components[0].id);
+      sim.buyCapacityRefill();
+    });
+
+    const log = a.getActionLog() as ActionLogEntry[];
+    const replayed = replayActionLog({
+      seed: 12345,
+      preset: 'SENIOR',
+      log,
+      bounds: BOUNDS,
+      untilTimeSec: a.timeSec,
+    });
+
+    expect(replayed.simScore).toBeCloseTo(a.score, 10);
+    expect(replayed.rating).toBeCloseTo(a.rating, 10);
+    expect(replayed.timeSec).toBe(a.timeSec);
+  });
+
+  it('replaying the log against a different seed produces a different score', () => {
+    const a = runScripted(98765, 90, (sim) => {
+      sim.setSelected(sim.components[0].id);
+      sim.upgradeSelected();
+    });
+
+    // Same log, wrong seed. The seed is the one piece of state the log cannot
+    // encode — it's baked into the run's ReplayInput. Flipping it proves the
+    // seed is load-bearing for verification.
+    const replayed = replayActionLog({
+      seed: 1,
+      preset: 'SENIOR',
+      log: a.getActionLog().slice() as ActionLogEntry[],
+      bounds: BOUNDS,
+      untilTimeSec: a.timeSec,
+    });
+
+    expect(replayed.simScore).not.toBeCloseTo(a.score, 3);
+  });
+
+  it('endRun sets verified=true for an unmodified live run', () => {
+    const sim: any = new GameSim();
+    sim.setPreset('SENIOR');
+    sim.reset(BOUNDS, { seed: 42 });
+    sim.setRunning(true);
+    for (let i = 0; i < 40; i++) sim.tick();
+    // Force an end-of-run path without waiting a full shift.
+    (sim as any).endRun('SHIFT_COMPLETE', 0.01, 0.05, 120);
+
+    expect(sim.lastRun).toBeDefined();
+    expect(sim.lastRun.verified).toBe(true);
+  });
+
+  it('action log survives in field order across reset boundaries', () => {
+    const sim: any = new GameSim();
+    sim.setPreset('SENIOR');
+    sim.reset(BOUNDS, { seed: 1 });
+    sim.setSelected(sim.components[0].id);
+    sim.buyCapacityRefill();
+
+    // reset() clears the log for the next run.
+    sim.reset(BOUNDS, { seed: 2 });
+    const afterReset = sim.getActionLog();
+    expect(afterReset.length).toBe(0);
+
+    sim.buyCapacityRefill();
+    expect(sim.getActionLog().length).toBe(1);
+    expect(sim.getActionLog()[0].kind).toBe('buyCapacityRefill');
+  });
+
+  it('scenario replay matches live run byte-for-byte', () => {
+    const sim: any = new GameSim();
+    sim.loadScenario({
+      id: 'test-scenario',
+      seed: 0xBEEF,
+      preset: 'SENIOR',
+      incidentScript: [
+        { atSec: 30, kind: 'MEMORY_LEAK' },
+        { atSec: 60, kind: 'A11Y_REGRESSION' },
+      ],
+    }, BOUNDS);
+    sim.setRunning(true);
+    for (let i = 0; i < 90; i++) sim.tick();
+
+    const log = sim.getActionLog() as ActionLogEntry[];
+    const replayed = replayActionLog({
+      seed: 0xBEEF,
+      preset: 'SENIOR',
+      log,
+      bounds: BOUNDS,
+      untilTimeSec: sim.timeSec,
+    });
+
+    expect(replayed.simScore).toBeCloseTo(sim.score, 10);
+  });
+});

--- a/tests/unit/scoring.test.ts
+++ b/tests/unit/scoring.test.ts
@@ -11,9 +11,9 @@ describe('asymmetric scoring', () => {
       const sim = makeSim();
       sim.reset({ width: 800, height: 600 }, { seed: 1 });
       sim.running = true;
-      // Simulate some ticks to accumulate score
-      for (let i = 0; i < 30; i++) sim.tick();
-      // Force budget depletion
+      // endRun is now idempotent per run (v0.4). Force BUDGET_DEPLETED as the
+      // first terminal event: pin rating high, drop budget, run one tick.
+      sim.rating = 5.0;
       sim.budget = -1;
       sim.tick();
       expect(sim.lastRun).not.toBeNull();
@@ -25,8 +25,8 @@ describe('asymmetric scoring', () => {
       const sim = makeSim();
       sim.reset({ width: 800, height: 600 }, { seed: 1 });
       sim.running = true;
-      for (let i = 0; i < 10; i++) sim.tick();
       sim.rating = 0.5;
+      sim.budget = 1000; // keep budget positive so RATING_COLLAPSED wins
       sim.tick();
       expect(sim.lastRun).not.toBeNull();
       expect(sim.lastRun.endReason).toBe('RATING_COLLAPSED');


### PR DESCRIPTION
Every run now records a full action log of the player's mutations (component placement, links, upgrades, ticket fixes, purchases, achievement rewards, etc.). On endRun, a fresh sim replays the log against the same seed and preset and the sim-side score is compared to the live run. A `verified` flag lands on RunResult and drives a small badge in the end-of-run modal. Logs are persisted per run under localStorage key `asr:runs:v1` so future server-side validation has a well-defined payload to consume.

This is Phase 1 of the server-side-validation work described in [docs/ROADMAP.md](./docs/ROADMAP.md). Phase 2 (Cloudflare Worker scoreboard) and Phase 3 (hardening) are documented there without shipping code.

- Instrumented every public GameSim mutator with recordAction; three new wrappers (setSelected / setRunning / applyReward) route direct field mutations from main.ts through the log.
- New src/actionlog.ts with replayActionLog and an applyAction dispatcher.
- endRun compares live simScore to a replayed simScore and sets lastRun.verified. Idempotent: endRun is now a no-op if a run has already ended (prevents redundant verification on post-terminal ticks).
- Persist per-runId action logs under asr:runs:v1 (cap 20).
- ✓ Verified / ✗ Replay mismatch badge in the end-of-run modal.
- docs/ROADMAP.md describing Phase 2 and Phase 3.