### PR TITLE
Sidebar dashboard + canvas HUD rework

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,56 @@
           <button id="btnZoomIn" class="btn hud" data-i18n-title="canvas.zoomIn" title="Zoom in" aria-label="Zoom in">+</button>
           <button id="btnZoomFit" class="btn hud" data-i18n-title="canvas.fit" title="Fit" aria-label="Fit to view">⤢</button>
         </div>
+        <div class="canvasHud canvasHud--actions" role="group" aria-label="Capacity and shop">
+          <div class="capRow">
+            <div class="capBar" role="progressbar" aria-labelledby="capBarLabel" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100">
+              <div id="capBarLabel" class="capBarLabel"><span data-i18n="backlog.capacity">Capacity</span> <span id="capVal" class="mono">0/0</span> <span id="capRegenHint" class="small muted mono">+0/min</span></div>
+              <div class="capBarTrack"><div id="capBarFill" class="capBarFill"></div></div>
+            </div>
+            <div class="capBtns capBtns--primary">
+              <button id="btnCapRefill" class="btn tonal" data-i18n-title="btn.refill" title="Refill">
+                <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="16" height="10" rx="2"/><line x1="22" y1="11" x2="22" y2="13"/><polyline points="11 9 8 13 12 13 9 17"/></svg>
+                <span class="btn-label" data-i18n="btn.refill">Refill</span>
+              </button>
+            </div>
+            <div class="capBtns capBtns--secondary">
+              <button id="btnCapBoost" class="btn tonal" data-i18n-title="btn.boostRegen" title="Boost regen">
+                <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="13" r="8"/><path d="M12 9v4l2 2"/><path d="M10 3h4"/></svg>
+                <span class="btn-label" data-i18n="btn.boostRegen">Boost regen</span>
+              </button>
+              <button id="btnCapHire" class="btn tonal" data-i18n-title="btn.hire" title="Hire">
+                <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><line x1="19" y1="8" x2="19" y2="14"/><line x1="22" y1="11" x2="16" y2="11"/></svg>
+                <span class="btn-label" data-i18n="btn.hire">Hire</span>
+              </button>
+            </div>
+            <div class="capBtns capBtns--gated">
+              <button id="btnCapDrink" class="btn tonal" hidden data-i18n-title="btn.energyDrinkTitle" title="Temporary regen booster (unlocks via achievements)">
+                <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+                <span class="btn-label" data-i18n="btn.energyDrink">Energy drink</span>
+              </button>
+              <button id="btnCapShield" class="btn tonal" hidden data-i18n-title="btn.incidentShieldTitle" title="Blocks the next incident penalty once (unlocks via achievements)">
+                <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l8 3v6c0 5-3.5 9-8 11-4.5-2-8-6-8-11V5l8-3z"/></svg>
+                <span class="btn-label" data-i18n="btn.incidentShield">Incident shield</span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <!-- Incident response: shown briefly when a new incident hits -->
+        <div id="incidentOverlay" class="incidentOverlay" hidden aria-live="polite" aria-atomic="true">
+          <div class="card incidentOverlayInner">
+            <div class="row" style="align-items:center;">
+              <div class="pill" style="border-color: color-mix(in oklab, var(--md-sys-color-error) 70%, transparent);" data-i18n="incident.label">Incident</div>
+              <div id="incidentOverlayTitle" class="small mono" style="margin-left:10px; flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">-</div>
+              <button id="incidentOverlayDismiss" class="btn text" aria-label="Dismiss incident" data-i18n-aria-label="incident.dismiss">✕</button>
+            </div>
+            <div id="incidentOverlayHint" class="small muted" style="margin-top:8px;" data-i18n="incident.hint">Respond fast: fix or defer the top ticket to stop the bleed.</div>
+            <div class="row" style="margin-top:10px; justify-content:flex-end; flex-wrap:wrap;">
+              <button id="incidentOverlayBacklog" class="btn outlined" data-i18n="btn.openBacklog">Open backlog</button>
+              <button id="incidentOverlayRefill" class="btn outlined" data-i18n="btn.refill">Refill</button>
+              <button id="incidentOverlayTriage" class="btn filled" data-i18n="btn.quickTriage">Quick triage</button>
+            </div>
+          </div>
+        </div>
       </div>
 
       <aside class="side" aria-label="Dashboard">
@@ -65,6 +115,28 @@
             <button class="tabBtn" id="tabBtnSignals" role="tab" aria-selected="false" aria-controls="tabSignals" data-tab="signals" data-i18n="nav.signals">Signals</button>
             <button class="tabBtn" id="tabBtnHistory" role="tab" aria-selected="false" aria-controls="tabHistory" data-tab="history" data-i18n="nav.history">History</button>
           </div>
+
+          <!-- Primary metrics: always visible in the sticky status strip -->
+          <section class="metricsGrid metricsGrid--primary" aria-label="Primary metrics" aria-live="polite" aria-atomic="false">
+            <div class="card">
+              <div class="k" data-i18n="lbl.budget">Budget</div>
+              <div class="v v-lg mono" id="budget">$500</div>
+            </div>
+            <div class="card">
+              <div class="k" data-i18n="lbl.rating">Rating</div>
+              <div class="v v-lg mono" id="rating">5.0 ★</div>
+              <svg id="sparkRating" class="sparkline" aria-hidden="true"></svg>
+            </div>
+            <div class="card">
+              <div class="k" data-i18n="lbl.shift">Shift</div>
+              <div class="v mono" id="shift">0:00 / 9:00</div>
+            </div>
+            <div class="card">
+              <div class="k" data-i18n="lbl.score">Score</div>
+              <div class="v v-lg mono" id="score">0</div>
+              <span id="comboIndicator" class="pill pill-combo" hidden>COMBO x1</span>
+            </div>
+          </section>
         </div>
 
         <div id="sideBody" class="sideBody">
@@ -91,28 +163,6 @@
             </button>
           </div>
           <div class="small" style="margin-top:8px;" data-i18n="sel.hint">Upgrades raise capacity & reliability. Repairs restore health. Both cost budget</div>
-        </section>
-
-        <!-- Tier 1: Primary metrics (always visible) -->
-        <section class="metricsGrid metricsGrid--primary" aria-label="Primary metrics" aria-live="polite" aria-atomic="false">
-          <div class="card">
-            <div class="k" data-i18n="lbl.budget">Budget</div>
-            <div class="v v-lg mono" id="budget">$500</div>
-          </div>
-          <div class="card">
-            <div class="k" data-i18n="lbl.rating">Rating</div>
-            <div class="v v-lg mono" id="rating">5.0 ★</div>
-            <svg id="sparkRating" class="sparkline" aria-hidden="true"></svg>
-          </div>
-          <div class="card">
-            <div class="k" data-i18n="lbl.shift">Shift</div>
-            <div class="v mono" id="shift">0:00 / 9:00</div>
-          </div>
-          <div class="card">
-            <div class="k" data-i18n="lbl.score">Score</div>
-            <div class="v v-lg mono" id="score">0</div>
-            <span id="comboIndicator" class="pill pill-combo" hidden>COMBO x1</span>
-          </div>
         </section>
 
         <!-- Tier 2: System health (collapsible) -->
@@ -284,35 +334,6 @@
         <section id="tabBacklog" class="tabPanel" role="tabpanel" aria-labelledby="tabBtnBacklog">
         <section class="card" id="backlogCard">
           <div class="k" data-i18n="nav.backlog">Backlog</div>
-          <div class="capRow">
-            <div class="capBar" role="progressbar" aria-labelledby="capBarLabel" aria-valuemin="0" aria-valuemax="100" aria-valuenow="100">
-              <div id="capBarLabel" class="capBarLabel"><span data-i18n="backlog.capacity">Capacity</span> <span id="capVal" class="mono">0/0</span> <span id="capRegenHint" class="small muted mono">+0/min</span></div>
-              <div class="capBarTrack"><div id="capBarFill" class="capBarFill"></div></div>
-            </div>
-            <div class="capBtns">
-              <button id="btnCapRefill" class="btn tonal" data-i18n-title="btn.refill" title="Refill">
-                <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="16" height="10" rx="2"/><line x1="22" y1="11" x2="22" y2="13"/><polyline points="11 9 8 13 12 13 9 17"/></svg>
-                <span class="btn-label" data-i18n="btn.refill">Refill</span>
-              </button>
-              <button id="btnCapBoost" class="btn tonal" data-i18n-title="btn.boostRegen" title="Boost regen">
-                <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="13" r="8"/><path d="M12 9v4l2 2"/><path d="M10 3h4"/></svg>
-                <span class="btn-label" data-i18n="btn.boostRegen">Boost regen</span>
-              </button>
-              <button id="btnCapDrink" class="btn tonal" hidden data-i18n-title="btn.energyDrinkTitle" title="Temporary regen booster (unlocks via achievements)">
-                <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
-                <span class="btn-label" data-i18n="btn.energyDrink">Energy drink</span>
-              </button>
-              <button id="btnCapShield" class="btn tonal" hidden data-i18n-title="btn.incidentShieldTitle" title="Blocks the next incident penalty once (unlocks via achievements)">
-                <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l8 3v6c0 5-3.5 9-8 11-4.5-2-8-6-8-11V5l8-3z"/></svg>
-                <span class="btn-label" data-i18n="btn.incidentShield">Incident shield</span>
-              </button>
-              <button id="btnCapHire" class="btn tonal" data-i18n-title="btn.hire" title="Hire">
-                <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><line x1="19" y1="8" x2="19" y2="14"/><line x1="22" y1="11" x2="16" y2="11"/></svg>
-                <span class="btn-label" data-i18n="btn.hire">Hire</span>
-              </button>
-            </div>
-            <div class="small muted capHint" data-i18n="backlog.fixOrDefer">Fix tickets or defer</div>
-          </div>
           <div id="ticketList" class="ticketList" style="margin-top:10px;"></div>
         </section>
 
@@ -424,23 +445,6 @@
         </div> <!-- /sideBody -->
 
       </aside>
-    </div>
-
-    <!-- Incident response: shown briefly when a new incident hits -->
-    <div id="incidentOverlay" class="incidentOverlay" hidden aria-live="polite" aria-atomic="true">
-      <div class="card incidentOverlayInner">
-        <div class="row" style="align-items:center;">
-          <div class="pill" style="border-color: color-mix(in oklab, var(--md-sys-color-error) 70%, transparent);" data-i18n="incident.label">Incident</div>
-          <div id="incidentOverlayTitle" class="small mono" style="margin-left:10px; flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">-</div>
-          <button id="incidentOverlayDismiss" class="btn text" aria-label="Dismiss incident" data-i18n-aria-label="incident.dismiss">✕</button>
-        </div>
-        <div id="incidentOverlayHint" class="small muted" style="margin-top:8px;" data-i18n="incident.hint">Respond fast: fix or defer the top ticket to stop the bleed.</div>
-        <div class="row" style="margin-top:10px; justify-content:flex-end; flex-wrap:wrap;">
-          <button id="incidentOverlayBacklog" class="btn outlined" data-i18n="btn.openBacklog">Open backlog</button>
-          <button id="incidentOverlayRefill" class="btn outlined" data-i18n="btn.refill">Refill</button>
-          <button id="incidentOverlayTriage" class="btn filled" data-i18n="btn.quickTriage">Quick triage</button>
-        </div>
-      </div>
     </div>
 
     <!-- Welcome / onboarding modal (first visit only) -->

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -167,7 +167,6 @@ const DICTS: Partial<Record<Lang, Dict>> = {
     'btn.incidentShield': 'Incident shield',
     'btn.incidentShieldTitle': 'Blocks the next incident penalty once (unlocks via achievements)',
     'btn.hire': 'Hire',
-    'backlog.fixOrDefer': 'Fix tickets or defer',
     'platform.latestApi': 'Latest API',
     'platform.minApi': 'Min API',
     'platform.oldDevices': 'Old devices',

--- a/src/main.ts
+++ b/src/main.ts
@@ -445,50 +445,32 @@ function setActiveTab(id: TabId) {
   }
 }
 
-function scrollToTab(id: TabId, behavior: ScrollBehavior = 'smooth') {
+function scrollToTab(id: TabId, _behavior: ScrollBehavior = 'smooth') {
   const section = tabSections[id];
   if (!section) return;
   setActiveTab(id);
 
-  // `offsetTop` can be misleading inside flex/scroll containers; compute the
-  // target position relative to the scroll container instead.
-  const parent = refs.sideBody;
-  const parentRect = parent.getBoundingClientRect();
-  const rect = section.getBoundingClientRect();
-  const top = Math.max(0, parent.scrollTop + (rect.top - parentRect.top) - 8);
-  parent.scrollTo({ top, behavior });
+  for (const k of Object.keys(tabSections) as TabId[]) {
+    const panel = tabSections[k];
+    const on = k === id;
+    panel.classList.toggle('is-active', on);
+    panel.hidden = !on;
+  }
+
+  // Each tab opens at the top.
+  refs.sideBody.scrollTop = 0;
 }
 
 const initialTab = (() => {
   try { return (localStorage.getItem(TAB_KEY) as TabId) || 'overview'; } catch { return 'overview'; }
 })();
 
-// highlight based on scroll position
-let tabRAF = 0;
-refs.sideBody.addEventListener('scroll', () => {
-  if (tabRAF) return;
-  tabRAF = window.requestAnimationFrame(() => {
-    tabRAF = 0;
-    const st = refs.sideBody.scrollTop;
-    let best: TabId = 'overview';
-    let bestDist = Number.POSITIVE_INFINITY;
-    const parentRect = refs.sideBody.getBoundingClientRect();
-    for (const id of Object.keys(tabSections) as TabId[]) {
-      const rect = tabSections[id].getBoundingClientRect();
-      const top = refs.sideBody.scrollTop + (rect.top - parentRect.top);
-      const dist = Math.abs(top - st);
-      if (dist < bestDist) { bestDist = dist; best = id; }
-    }
-    setActiveTab(best);
-  });
-}, { passive: true });
-
 refs.tabBtnOverview.addEventListener('click', () => scrollToTab('overview'));
 refs.tabBtnBacklog.addEventListener('click', () => scrollToTab('backlog'));
 refs.tabBtnSignals.addEventListener('click', () => scrollToTab('signals'));
 refs.tabBtnHistory.addEventListener('click', () => scrollToTab('history'));
 
-// Initial jump (no smooth) once layout is ready
+// Initial activation once layout is ready
 requestAnimationFrame(() => scrollToTab(initialTab, 'auto'));
 
 // Theme (System / Light / Dark)

--- a/src/style.css
+++ b/src/style.css
@@ -342,6 +342,25 @@ button, input, select, textarea {
   z-index: 2;
 }
 
+.canvasHud--actions {
+  top: auto;
+  right: auto;
+  left: 10px;
+  bottom: 10px;
+  flex-direction: column;
+  gap: 8px;
+  max-width: min(360px, calc(100% - 20px));
+  background: var(--md-sys-color-surface-container-high);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--md-sys-shape-corner-large);
+  padding: 10px;
+  box-shadow: var(--md-elevation-1);
+}
+
+.canvasHud--actions .btn {
+  padding: 6px 10px;
+}
+
 .btn.hud {
   padding: 6px 10px;
   min-width: 34px;
@@ -435,7 +454,8 @@ canvas {
   color: var(--md-sys-color-on-primary-container);
 }
 
-.tabPanel { display: flex; flex-direction: column; gap: 12px; }
+.tabPanel { display: none; }
+.tabPanel.is-active { display: flex; flex-direction: column; gap: 12px; }
 
 /* Mobile polish: tabs remain usable even when the panel is narrow. */
 @media (max-width: 900px) {
@@ -531,11 +551,9 @@ h1 {
 .capBarFill.is-med { background: var(--color-warn, #d69a1a); }
 .capRow .capBtns { display: flex; gap: 6px; flex-wrap: wrap; }
 .capRow .capBtns .btn { padding: 8px 10px; }
-.capHint { color: var(--md-sys-color-on-surface-variant); }
 
 @media (max-width: 540px) {
   .capRow .capBtns { margin-left:0; width:100%; }
-  .capRow .capRight { margin-left:0; width:100%; white-space:normal; }
 }
 
 /* High-signal metrics block: adapts from 2 cols to 3/4 based on available width */
@@ -552,6 +570,19 @@ h1 {
 
 .metricsGrid--primary .card {
   border-left: 3px solid var(--md-sys-color-primary);
+}
+
+/* Compact variant used inside the sticky status strip. Tighter spacing
+   keeps Budget / Rating / Shift / Score always on screen without
+   crowding the header. */
+.sideHeader .metricsGrid--primary {
+  gap: 6px;
+  padding-top: 4px;
+  padding-bottom: 10px;
+}
+
+.sideHeader .metricsGrid--primary .card {
+  padding: 8px 10px;
 }
 
 .metricsPanel {
@@ -1292,12 +1323,12 @@ html.incident-hot #backlogCard {
 }
 
 .incidentOverlay {
-  position: fixed;
+  position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  bottom: 16px;
-  z-index: 9999;
-  width: min(440px, calc(100vw - 32px));
+  top: 10px;
+  z-index: 3;
+  width: min(440px, calc(100% - 32px));
   pointer-events: none;
 }
 
@@ -1451,6 +1482,7 @@ html.incident-hot #backlogCard {
 
 @media (max-width: 980px) {
   .incidentOverlay {
+    position: absolute;
     left: 12px;
     right: 12px;
     top: 12px;


### PR DESCRIPTION
The right sidebar mixed live metrics, shop buttons, and a ticket list into one long scroll. This reworks it into three distinct surfaces:

- **Sticky status strip**: Budget/Rating/Shift/Score live in the sidebar header and stay visible on every tab.
- **Real tab panel swap**: tabs show one panel at a time instead of scrolling a stacked column. Each tab opens at the top.
- **Canvas HUD actions**: capacity bar and shop buttons (Refill / Boost / Hire + gated Energy Drink / Shield) sit bottom-left on the game field where they belong.
- **Incident overlay**: reanchored to the top of the canvas so it reads as a status banner and stops colliding with the new HUD.

All `must('id')` DOM hooks preserved. Backlog card is now single-purpose (heading + ticket list). Removed the dead `backlog.fixOrDefer` caption.

## Verification
- `npm run test:dom` 140/140 ids
- `npm run test:unit` 138/138
- `npm run build` clean
- `npm run test:e2e` 10/10 (tab selection test still green)