### PR TITLE
Cloudflare Workers Static Assets config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,8 +6,20 @@ export default defineConfig(() => {
   // Default is "/" so local builds and previews always work.
   const base = process.env.VITE_BASE ?? '/';
 
+  // GH Actions sets VITE_COMMIT_SHA explicitly; Cloudflare Workers Builds
+  // exposes WORKERS_CI_COMMIT_SHA; legacy Cloudflare Pages set CF_PAGES_COMMIT_SHA.
+  const commitSha =
+    process.env.VITE_COMMIT_SHA
+    ?? process.env.WORKERS_CI_COMMIT_SHA
+    ?? process.env.CF_PAGES_COMMIT_SHA
+    ?? 'dev';
+
   return {
     base,
+    plugins: [],
+    define: {
+      'import.meta.env.VITE_COMMIT_SHA': JSON.stringify(commitSha),
+    },
     server: {
       port: 5173,
       strictPort: true

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,13 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "app-survival-android",
+  "compatibility_date": "2026-04-22",
+  "observability": {
+    "enabled": true
+  },
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application"
+  },
+  "compatibility_flags": ["nodejs_compat"]
+}


### PR DESCRIPTION
Unblocks Cloudflare's deploy (was failing with 'Cannot modify Vite config: could not find a valid plugins array').

- `vite.config.ts`: adds `plugins: []` so CF auto-config can inject its plugin. Adds a commit-sha fallback chain (VITE_COMMIT_SHA -> WORKERS_CI_COMMIT_SHA -> CF_PAGES_COMMIT_SHA -> 'dev') via `define` so the build-info line shows the right hash on any CI.
- `wrangler.jsonc`: source-controlled deploy target (name, compatibility_date 2026-04-22, observability on, SPA fallback on `./dist`).

GH Pages deploy keeps working unchanged.