### PR TITLE
Document hosting split (GH Pages prod, Cloudflare previews)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,6 @@
+# Production deploy. GitHub Pages is the production host (live demo URL in README).
+# Per-PR previews are owned by Cloudflare (see wrangler.jsonc); this workflow only
+# fires on main so the two paths never race for the same URL.
 name: Deploy to GitHub Pages
 
 on:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ Inspired by Server Survival by pshenok at https://pshenok.github.io/server-survi
 Live demo
 https://pzverkov.github.io/app-survival-android/
 
+## Hosting
+
+Production is served from GitHub Pages at the live demo URL above, deployed by
+`.github/workflows/deploy.yml` on every push to `main`.
+
+Per-PR previews are served from Cloudflare Workers Static Assets (configured in
+`wrangler.jsonc`). The Cloudflare project's "Production branch" is intentionally
+set to a non-existent branch so only PR builds publish; production deploys are
+owned by GitHub Pages. Each PR gets a unique preview URL posted as a status
+check on the PR by the Cloudflare GitHub App.
+
 ## Table of contents
 - Purpose
 - Quick start

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,3 +1,7 @@
+// Cloudflare Workers Static Assets — used for per-PR preview deployments only.
+// Production is served from GitHub Pages (see .github/workflows/deploy.yml).
+// The Cloudflare project's "Production branch" is set to a non-existent branch
+// in the dashboard so main never auto-deploys here.
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "app-survival-android",


### PR DESCRIPTION
Locks in the split:

- **Production**: GitHub Pages, deployed by `.github/workflows/deploy.yml` on push to main. Live demo URL unchanged.
- **PR previews**: Cloudflare Workers Static Assets, configured in `wrangler.jsonc`. The Cloudflare project's 'Production branch' is set to a non-existent branch in the dashboard so main never auto-deploys to CF.

Adds a README 'Hosting' section and cross-referencing header comments in both config files so the new contributor doesn't have to reverse-engineer why both deploy paths exist.