### PR TITLE
Move Backlog to bottom-right canvas HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,12 @@
             </div>
           </div>
         </div>
+        <div class="canvasHud canvasHud--backlog" role="region" aria-label="Backlog">
+          <section class="card" id="backlogCard">
+            <div class="k" data-i18n="nav.backlog">Backlog</div>
+            <div id="ticketList" class="ticketList" style="margin-top:10px;"></div>
+          </section>
+        </div>
         <!-- Incident response: shown briefly when a new incident hits -->
         <div id="incidentOverlay" class="incidentOverlay" hidden aria-live="polite" aria-atomic="true">
           <div class="card incidentOverlayInner">
@@ -111,7 +117,6 @@
 
           <div class="tabBar" role="tablist" aria-label="Sections">
             <button class="tabBtn is-selected" id="tabBtnOverview" role="tab" aria-selected="true" aria-controls="tabOverview" data-tab="overview" data-i18n="nav.overview">Overview</button>
-            <button class="tabBtn" id="tabBtnBacklog" role="tab" aria-selected="false" aria-controls="tabBacklog" data-tab="backlog" data-i18n="nav.backlog">Backlog</button>
             <button class="tabBtn" id="tabBtnSignals" role="tab" aria-selected="false" aria-controls="tabSignals" data-tab="signals" data-i18n="nav.signals">Signals</button>
             <button class="tabBtn" id="tabBtnHistory" role="tab" aria-selected="false" aria-controls="tabHistory" data-tab="history" data-i18n="nav.history">History</button>
           </div>
@@ -163,6 +168,17 @@
             </button>
           </div>
           <div class="small" style="margin-top:8px;" data-i18n="sel.hint">Upgrades raise capacity & reliability. Repairs restore health. Both cost budget</div>
+        </section>
+
+        <section class="card">
+          <div class="row" style="align-items:center;">
+            <div class="k" data-i18n="card.roadmap">Refactor Roadmap</div>
+            <div style="margin-left:auto;">
+              <button id="btnApplyNextRoadmap" class="btn text" data-i18n="btn.applyNext">Apply next</button>
+            </div>
+          </div>
+          <div class="small muted" style="margin-top:6px;" data-i18n="history.roadmapHint">Suggested sequence to pay down architecture debt (Staff/Principal-style).</div>
+          <pre class="small" id="roadmap" style="margin-top:8px;" data-i18n="history.noRoadmap">No roadmap yet.</pre>
         </section>
 
         <!-- Tier 2: System health (collapsible) -->
@@ -330,33 +346,6 @@
         </div>
 
         </section> <!-- /tabOverview -->
-
-        <section id="tabBacklog" class="tabPanel" role="tabpanel" aria-labelledby="tabBtnBacklog">
-        <section class="card" id="backlogCard">
-          <div class="k" data-i18n="nav.backlog">Backlog</div>
-          <div id="ticketList" class="ticketList" style="margin-top:10px;"></div>
-        </section>
-
-
-
-        
-        <section class="card">
-          <div class="row" style="align-items:center;">
-            <div class="k" data-i18n="card.roadmap">Refactor Roadmap</div>
-            <div style="margin-left:auto;">
-              <button id="btnApplyNextRoadmap" class="btn text" data-i18n="btn.applyNext">Apply next</button>
-            </div>
-          </div>
-          <div class="small muted" style="margin-top:6px;" data-i18n="history.roadmapHint">Suggested sequence to pay down architecture debt (Staff/Principal-style).</div>
-          <pre class="small" id="roadmap" style="margin-top:8px;" data-i18n="history.noRoadmap">No roadmap yet.</pre>
-        </section>
-
-
-        
-
-        
-
-        </section> <!-- /tabBacklog -->
 
         <section id="tabSignals" class="tabPanel" role="tabpanel" aria-labelledby="tabBtnSignals">
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,11 +135,9 @@ type UIRefs = {
   btnZoomFit: HTMLButtonElement;
 
   tabBtnOverview: HTMLButtonElement;
-  tabBtnBacklog: HTMLButtonElement;
   tabBtnSignals: HTMLButtonElement;
   tabBtnHistory: HTMLButtonElement;
   tabOverview: HTMLElement;
-  tabBacklog: HTMLElement;
   tabSignals: HTMLElement;
   tabHistory: HTMLElement;
 
@@ -344,7 +342,6 @@ function latestIncidentLine(eventsText: string): string {
 }
 
 function openBacklog() {
-  scrollToTab('backlog', IS_E2E ? 'auto' : 'smooth');
   const el = document.getElementById('backlogCard') ?? refs.ticketList;
   el.scrollIntoView({ behavior: IS_E2E ? 'auto' : 'smooth', block: 'start' });
 }
@@ -419,18 +416,16 @@ refs.presetSelect.addEventListener('change', () => {
 });
 
 // Tabs --------------------------------------------------------------------
-type TabId = 'overview' | 'backlog' | 'signals' | 'history';
+type TabId = 'overview' | 'signals' | 'history';
 
 const tabSections: Record<TabId, HTMLElement> = {
   overview: refs.tabOverview,
-  backlog: refs.tabBacklog,
   signals: refs.tabSignals,
   history: refs.tabHistory,
 };
 
 const tabButtons: Record<TabId, HTMLButtonElement> = {
   overview: refs.tabBtnOverview,
-  backlog: refs.tabBtnBacklog,
   signals: refs.tabBtnSignals,
   history: refs.tabBtnHistory,
 };
@@ -461,12 +456,15 @@ function scrollToTab(id: TabId, _behavior: ScrollBehavior = 'smooth') {
   refs.sideBody.scrollTop = 0;
 }
 
-const initialTab = (() => {
-  try { return (localStorage.getItem(TAB_KEY) as TabId) || 'overview'; } catch { return 'overview'; }
+const initialTab: TabId = (() => {
+  try {
+    const stored = localStorage.getItem(TAB_KEY);
+    if (stored === 'overview' || stored === 'signals' || stored === 'history') return stored;
+    return 'overview';
+  } catch { return 'overview'; }
 })();
 
 refs.tabBtnOverview.addEventListener('click', () => scrollToTab('overview'));
-refs.tabBtnBacklog.addEventListener('click', () => scrollToTab('backlog'));
 refs.tabBtnSignals.addEventListener('click', () => scrollToTab('signals'));
 refs.tabBtnHistory.addEventListener('click', () => scrollToTab('history'));
 
@@ -2197,11 +2195,9 @@ function bindUI(): UIRefs {
     btnZoomFit: must('btnZoomFit') as HTMLButtonElement,
 
     tabBtnOverview: must('tabBtnOverview') as HTMLButtonElement,
-    tabBtnBacklog: must('tabBtnBacklog') as HTMLButtonElement,
     tabBtnSignals: must('tabBtnSignals') as HTMLButtonElement,
     tabBtnHistory: must('tabBtnHistory') as HTMLButtonElement,
     tabOverview: must('tabOverview'),
-    tabBacklog: must('tabBacklog'),
     tabSignals: must('tabSignals'),
     tabHistory: must('tabHistory'),
 

--- a/src/style.css
+++ b/src/style.css
@@ -361,6 +361,37 @@ button, input, select, textarea {
   padding: 6px 10px;
 }
 
+.canvasHud--backlog {
+  top: auto;
+  left: auto;
+  right: 10px;
+  bottom: 10px;
+  flex-direction: column;
+  gap: 8px;
+  width: clamp(300px, 34%, 420px);
+  max-height: calc(100% - 20px);
+  background: var(--md-sys-color-surface-container-high);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--md-sys-shape-corner-large);
+  padding: 10px;
+  box-shadow: var(--md-elevation-1);
+  display: flex;
+  overflow: hidden;
+}
+
+.canvasHud--backlog #backlogCard {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.canvasHud--backlog .ticketList {
+  overflow-y: auto;
+  max-height: min(48vh, 420px);
+  padding-right: 4px;
+  grid-template-columns: 1fr;
+}
+
 .btn.hud {
   padding: 6px 10px;
   min-width: 34px;
@@ -461,6 +492,12 @@ canvas {
 @media (max-width: 900px) {
   .tabBar { padding-bottom: 10px; }
   .canvasHud { top: 8px; right: 8px; }
+  .canvasHud--actions,
+  .canvasHud--backlog {
+    width: calc(50% - 14px);
+    max-width: none;
+  }
+  .canvasHud--backlog .ticketList { max-height: 24vh; }
 }
 
 .sideHeader > * {

--- a/tests/e2e/core-flows.spec.ts
+++ b/tests/e2e/core-flows.spec.ts
@@ -38,15 +38,13 @@ test('budget decreases while game is running', async ({ page }) => {
 test('tab buttons toggle selection state', async ({ page }) => {
   await page.goto('/');
 
-  // Backlog tab should become selected
-  await page.click('#tabBtnBacklog');
-  await expect(page.locator('#tabBtnBacklog')).toHaveClass(/is-selected/);
+  await page.click('#tabBtnSignals');
+  await expect(page.locator('#tabBtnSignals')).toHaveClass(/is-selected/);
   await expect(page.locator('#tabBtnOverview')).not.toHaveClass(/is-selected/);
 
-  // History tab
   await page.click('#tabBtnHistory');
   await expect(page.locator('#tabBtnHistory')).toHaveClass(/is-selected/);
-  await expect(page.locator('#tabBtnBacklog')).not.toHaveClass(/is-selected/);
+  await expect(page.locator('#tabBtnSignals')).not.toHaveClass(/is-selected/);
 });
 
 test('daily seed button fills seed input', async ({ page }) => {

--- a/tests/e2e/crosscheck-reason.spec.ts
+++ b/tests/e2e/crosscheck-reason.spec.ts
@@ -22,10 +22,7 @@ test('gated tickets expose a cross-check reason string on the card', async ({ pa
   });
 
   // The backlog list must show at least one ticket with a reason attr.
-  // Scroll the backlog tab into view so the list renders.
-  await page.click('#tabBtnBacklog');
-  await page.waitForTimeout(200);
-
+  // The backlog HUD is always visible on the canvas, so we can query directly.
   const reasonTicket = page.locator('#ticketList .ticket[data-reason]').first();
   await expect(reasonTicket).toBeVisible();
 


### PR DESCRIPTION
Lifts the ticket list onto the canvas as a symmetric bottom-right HUD, mirroring the Capacity HUD on the left (commit ef2c5ff). Capacity (supply) and Backlog (demand) are now both on-canvas, so the player never has to swap tabs during an incident.

Refactor Roadmap moves to Overview next to Selected. Backlog tab button and panel are removed; sidebar tabs are now Overview / Signals / History.

Verification: unit tests (138/138), build, and Playwright e2e (10/10) all pass. Updated two e2e tests that targeted #tabBtnBacklog.