### PR TITLE
Compact sticky header, reflowing Capacity HUD, view-transition polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
               <div class="capBarTrack"><div id="capBarFill" class="capBarFill"></div></div>
             </div>
             <div class="capBtns capBtns--primary">
-              <button id="btnCapRefill" class="btn tonal" data-i18n-title="btn.refill" title="Refill">
+              <button id="btnCapRefill" class="btn filled" data-i18n-title="btn.refill" title="Refill">
                 <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="16" height="10" rx="2"/><line x1="22" y1="11" x2="22" y2="13"/><polyline points="11 9 8 13 12 13 9 17"/></svg>
                 <span class="btn-label" data-i18n="btn.refill">Refill</span>
               </button>
@@ -121,24 +121,24 @@
             <button class="tabBtn" id="tabBtnHistory" role="tab" aria-selected="false" aria-controls="tabHistory" data-tab="history" data-i18n="nav.history">History</button>
           </div>
 
-          <!-- Primary metrics: always visible in the sticky status strip -->
-          <section class="metricsGrid metricsGrid--primary" aria-label="Primary metrics" aria-live="polite" aria-atomic="false">
-            <div class="card">
-              <div class="k" data-i18n="lbl.budget">Budget</div>
-              <div class="v v-lg mono" id="budget">$500</div>
+          <!-- Primary metrics: always visible as a compact chip strip. -->
+          <section class="statusStrip" aria-label="Primary metrics" aria-live="polite" aria-atomic="false">
+            <div class="statusChip">
+              <span class="statusChip-k" data-i18n="lbl.budget">Budget</span>
+              <span class="statusChip-v mono" id="budget">$500</span>
             </div>
-            <div class="card">
-              <div class="k" data-i18n="lbl.rating">Rating</div>
-              <div class="v v-lg mono" id="rating">5.0 ★</div>
-              <svg id="sparkRating" class="sparkline" aria-hidden="true"></svg>
+            <div class="statusChip">
+              <span class="statusChip-k" data-i18n="lbl.rating">Rating</span>
+              <span class="statusChip-v mono" id="rating">5.0 ★</span>
+              <svg id="sparkRating" class="sparkline statusChip-spark" aria-hidden="true"></svg>
             </div>
-            <div class="card">
-              <div class="k" data-i18n="lbl.shift">Shift</div>
-              <div class="v mono" id="shift">0:00 / 9:00</div>
+            <div class="statusChip">
+              <span class="statusChip-k" data-i18n="lbl.shift">Shift</span>
+              <span class="statusChip-v mono" id="shift">0:00 / 9:00</span>
             </div>
-            <div class="card">
-              <div class="k" data-i18n="lbl.score">Score</div>
-              <div class="v v-lg mono" id="score">0</div>
+            <div class="statusChip">
+              <span class="statusChip-k" data-i18n="lbl.score">Score</span>
+              <span class="statusChip-v mono" id="score">0</span>
               <span id="comboIndicator" class="pill pill-combo" hidden>COMBO x1</span>
             </div>
           </section>

--- a/src/main.ts
+++ b/src/main.ts
@@ -443,17 +443,24 @@ function setActiveTab(id: TabId) {
 function scrollToTab(id: TabId, _behavior: ScrollBehavior = 'smooth') {
   const section = tabSections[id];
   if (!section) return;
-  setActiveTab(id);
 
-  for (const k of Object.keys(tabSections) as TabId[]) {
-    const panel = tabSections[k];
-    const on = k === id;
-    panel.classList.toggle('is-active', on);
-    panel.hidden = !on;
+  const apply = () => {
+    setActiveTab(id);
+    for (const k of Object.keys(tabSections) as TabId[]) {
+      const panel = tabSections[k];
+      const on = k === id;
+      panel.classList.toggle('is-active', on);
+      panel.hidden = !on;
+    }
+    refs.sideBody.scrollTop = 0;
+  };
+
+  const startVT = (document as any).startViewTransition;
+  if (!IS_E2E && typeof startVT === 'function') {
+    startVT.call(document, apply);
+  } else {
+    apply();
   }
-
-  // Each tab opens at the top.
-  refs.sideBody.scrollTop = 0;
 }
 
 const initialTab: TabId = (() => {

--- a/src/style.css
+++ b/src/style.css
@@ -349,16 +349,18 @@ button, input, select, textarea {
   bottom: 10px;
   flex-direction: column;
   gap: 8px;
-  max-width: min(360px, calc(100% - 20px));
+  width: clamp(260px, 34%, 520px);
   background: var(--md-sys-color-surface-container-high);
   border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--md-sys-shape-corner-large);
   padding: 10px;
   box-shadow: var(--md-elevation-1);
+  container-type: inline-size;
+  container-name: caphud;
 }
 
 .canvasHud--actions .btn {
-  padding: 6px 10px;
+  padding: 8px 10px;
 }
 
 .canvasHud--backlog {
@@ -432,6 +434,8 @@ canvas {
   flex-direction: column;
   gap: 12px;
   padding-top: 12px;
+  scrollbar-gutter: stable;
+  scroll-padding-top: 120px;
 }
 
 .sideHeader {
@@ -575,10 +579,17 @@ h1 {
 }
 
 /* Backlog capacity controls */
-/* Capacity toolbar: progress bar stacked above an icon-button chip row,
-   with the "Fix tickets or defer" hint as a subtle caption below. */
-.capRow { display: flex; flex-direction: column; gap: 10px; margin-top: 8px; }
-.capBar { display: flex; flex-direction: column; gap: 6px; }
+/* Capacity toolbar: capacity bar pinned on top, action buttons flow into
+   an auto-fit grid that uses all available horizontal space before wrapping.
+   Groups dissolve visually via display:contents so buttons are direct grid
+   items; semantic group divs stay in markup for future a11y labeling. */
+.capRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+  gap: 8px;
+  margin-top: 8px;
+}
+.capBar { grid-column: 1 / -1; display: flex; flex-direction: column; gap: 6px; }
 .capBarLabel { display: flex; align-items: baseline; gap: 8px; font-size: 13px; color: var(--md-sys-color-on-surface); }
 .capBarLabel #capVal { font-weight: 600; }
 .capBarLabel #capRegenHint { margin-left: auto; }
@@ -586,11 +597,25 @@ h1 {
 .capBarFill { height: 100%; background: var(--md-sys-color-primary); border-radius: 999px; transition: width 160ms ease, background 160ms ease; }
 .capBarFill.is-low { background: var(--color-danger, #e05a5a); }
 .capBarFill.is-med { background: var(--color-warn, #d69a1a); }
-.capRow .capBtns { display: flex; gap: 6px; flex-wrap: wrap; }
-.capRow .capBtns .btn { padding: 8px 10px; }
+.capRow > .capBtns { display: contents; }
+.capRow .btn { padding: 8px 10px; min-width: 0; }
 
-@media (max-width: 540px) {
-  .capRow .capBtns { margin-left:0; width:100%; }
+/* Give Refill (the primary action) more room when the HUD is wide enough. */
+@container caphud (width > 340px) {
+  .capRow .capBtns--primary .btn { grid-column: span 2; }
+}
+
+/* Narrow HUD: collapse button labels to icons so the row still fits. */
+@container caphud (width < 260px) {
+  .capRow .btn .btn-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+  .capRow .btn { padding: 8px; min-width: 40px; justify-content: center; }
 }
 
 /* High-signal metrics block: adapts from 2 cols to 3/4 based on available width */
@@ -600,26 +625,54 @@ h1 {
   gap: 10px;
 }
 
-.metricsGrid--primary {
-  grid-template-columns: repeat(2, 1fr);
-  gap: var(--space-3);
-}
-
-.metricsGrid--primary .card {
-  border-left: 3px solid var(--md-sys-color-primary);
-}
-
-/* Compact variant used inside the sticky status strip. Tighter spacing
-   keeps Budget / Rating / Shift / Score always on screen without
-   crowding the header. */
-.sideHeader .metricsGrid--primary {
+/* Status strip: compact chip row that keeps Budget / Rating / Shift / Score
+   always visible in the sticky header without eating vertical space. */
+.statusStrip {
+  display: flex;
+  flex-wrap: wrap;
   gap: 6px;
-  padding-top: 4px;
-  padding-bottom: 10px;
+  padding: 6px 12px 10px;
 }
 
-.sideHeader .metricsGrid--primary .card {
-  padding: 8px 10px;
+.statusChip {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--md-sys-color-surface-container) 86%, transparent);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  box-shadow: inset 0 1px 0 color-mix(in oklab, white 8%, transparent);
+  font-size: 12px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.statusChip-k {
+  color: var(--md-sys-color-on-surface-variant);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.statusChip-v {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.statusChip-spark {
+  width: 40px;
+  height: 14px;
+  margin-left: 2px;
+}
+
+.statusChip #comboIndicator {
+  margin-left: 2px;
+  padding: 2px 6px;
+  font-size: 10px;
 }
 
 .metricsPanel {
@@ -1057,10 +1110,10 @@ select:focus-visible {
     font-size: 18px;
   }
 
-  /* Compact metrics on small screens */
-  .metricsGrid--primary {
-    gap: var(--space-2);
-  }
+  /* Compact status strip chips on small screens */
+  .statusStrip { padding: 4px 10px 8px; gap: 4px; }
+  .statusChip { padding: 4px 8px; font-size: 11px; }
+  .statusChip-v { font-size: 12px; }
 }
 
 @media (max-width: 480px) {
@@ -1553,9 +1606,88 @@ html.incident-hot #backlogCard {
   }
 }
 
+/* --- Modern CSS polish (luxury pass) ----------------------------------- */
+
+/* Tighter typography: avoid orphans on headings and label strips. */
+h1, .k, .statusChip-k { text-wrap: balance; }
+
+/* Selected-card conic halo. Pure CSS: gated via :has() on the Upgrade
+   button's enabled state, which reflects "a node is selected". */
+@property --sel-angle {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+}
+
+#selCard {
+  position: relative;
+  isolation: isolate;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  #selCard:has(#btnUpgrade:not(:disabled))::before {
+    content: '';
+    position: absolute;
+    inset: -1px;
+    border-radius: inherit;
+    padding: 1px;
+    background: conic-gradient(
+      from var(--sel-angle),
+      transparent 0deg,
+      color-mix(in oklab, var(--md-sys-color-primary) 85%, transparent) 90deg,
+      transparent 180deg,
+      color-mix(in oklab, var(--md-sys-color-primary) 55%, transparent) 270deg,
+      transparent 360deg
+    );
+    -webkit-mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+            mask-composite: exclude;
+    animation: selHaloSpin 6s linear infinite;
+    pointer-events: none;
+    z-index: -1;
+  }
+}
+
+@keyframes selHaloSpin {
+  to { --sel-angle: 360deg; }
+}
+
+/* Scroll-driven reveal on sidebar cards. Uses view() timeline so each
+   card fades and rises as it enters the scroll viewport. Gated by
+   reduced-motion and feature support. */
+@supports (animation-timeline: view()) {
+  @media (prefers-reduced-motion: no-preference) {
+    .sideBody .card {
+      animation: cardReveal linear both;
+      animation-timeline: view();
+      animation-range: entry 0% entry 40%;
+    }
+  }
+}
+
+@keyframes cardReveal {
+  from { opacity: 0.35; transform: translateY(8px); }
+  to   { opacity: 1;    transform: translateY(0); }
+}
+
+/* View-transition crossfade on tab change. Opt in via a class on <html>
+   set by main.ts only for the transition duration. */
+::view-transition-old(tab-panel),
+::view-transition-new(tab-panel) {
+  animation-duration: 180ms;
+  animation-timing-function: ease;
+}
+
+.tabPanel.is-active {
+  view-transition-name: tab-panel;
+}
+
 /* E2E: reduce motion to avoid flaky timing in headless browsers */
 html.e2e *, html.e2e *::before, html.e2e *::after {
   animation: none !important;
   transition: none !important;
   scroll-behavior: auto !important;
+  view-transition-name: none !important;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -350,11 +350,20 @@ button, input, select, textarea {
   flex-direction: column;
   gap: 8px;
   width: clamp(260px, 34%, 520px);
-  background: var(--md-sys-color-surface-container-high);
+  background-color: color-mix(in oklab, var(--md-sys-color-surface-container-high) 82%, transparent);
+  background-image: linear-gradient(
+    180deg,
+    color-mix(in oklab, white 5%, transparent) 0%,
+    transparent 40%
+  );
+  backdrop-filter: saturate(140%) blur(10px);
+  -webkit-backdrop-filter: saturate(140%) blur(10px);
   border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--md-sys-shape-corner-large);
   padding: 10px;
-  box-shadow: var(--md-elevation-1);
+  box-shadow:
+    var(--md-elevation-2),
+    inset 0 1px 0 color-mix(in oklab, white 10%, transparent);
   container-type: inline-size;
   container-name: caphud;
 }
@@ -372,11 +381,20 @@ button, input, select, textarea {
   gap: 8px;
   width: clamp(300px, 34%, 420px);
   max-height: calc(100% - 20px);
-  background: var(--md-sys-color-surface-container-high);
+  background-color: color-mix(in oklab, var(--md-sys-color-surface-container-high) 82%, transparent);
+  background-image: linear-gradient(
+    180deg,
+    color-mix(in oklab, white 5%, transparent) 0%,
+    transparent 40%
+  );
+  backdrop-filter: saturate(140%) blur(10px);
+  -webkit-backdrop-filter: saturate(140%) blur(10px);
   border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--md-sys-shape-corner-large);
   padding: 10px;
-  box-shadow: var(--md-elevation-1);
+  box-shadow:
+    var(--md-elevation-2),
+    inset 0 1px 0 color-mix(in oklab, white 10%, transparent);
   display: flex;
   overflow: hidden;
 }
@@ -580,16 +598,16 @@ h1 {
 
 /* Backlog capacity controls */
 /* Capacity toolbar: capacity bar pinned on top, action buttons flow into
-   an auto-fit grid that uses all available horizontal space before wrapping.
-   Groups dissolve visually via display:contents so buttons are direct grid
-   items; semantic group divs stay in markup for future a11y labeling. */
+   a flex-wrap row that respects each button's intrinsic text width so
+   labels never smash. Groups dissolve via display:contents for layout. */
 .capRow {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   margin-top: 8px;
+  align-items: stretch;
 }
-.capBar { grid-column: 1 / -1; display: flex; flex-direction: column; gap: 6px; }
+.capBar { flex: 1 0 100%; display: flex; flex-direction: column; gap: 6px; }
 .capBarLabel { display: flex; align-items: baseline; gap: 8px; font-size: 13px; color: var(--md-sys-color-on-surface); }
 .capBarLabel #capVal { font-weight: 600; }
 .capBarLabel #capRegenHint { margin-left: auto; }
@@ -598,14 +616,17 @@ h1 {
 .capBarFill.is-low { background: var(--color-danger, #e05a5a); }
 .capBarFill.is-med { background: var(--color-warn, #d69a1a); }
 .capRow > .capBtns { display: contents; }
-.capRow .btn { padding: 8px 10px; min-width: 0; }
+/* flex: 1 0 auto — grow to share extra space; don't shrink below content;
+   basis auto so the button is at least as wide as icon + label. This is
+   what keeps "Boost regen"/"Incident shield" from getting visually smashed. */
+.capRow .btn { flex: 1 0 auto; padding: 8px 12px; }
 
-/* Give Refill (the primary action) more room when the HUD is wide enough. */
+/* Give Refill (the primary action) extra weight when the HUD is wide. */
 @container caphud (width > 340px) {
-  .capRow .capBtns--primary .btn { grid-column: span 2; }
+  .capRow .capBtns--primary .btn { flex-grow: 2.5; }
 }
 
-/* Narrow HUD: collapse button labels to icons so the row still fits. */
+/* Narrow HUD: collapse labels to icons so buttons still fit cleanly. */
 @container caphud (width < 260px) {
   .capRow .btn .btn-label {
     position: absolute;
@@ -615,7 +636,7 @@ h1 {
     clip-path: inset(50%);
     white-space: nowrap;
   }
-  .capRow .btn { padding: 8px; min-width: 40px; justify-content: center; }
+  .capRow .btn { flex: 0 0 40px; padding: 8px; min-width: 40px; justify-content: center; }
 }
 
 /* High-signal metrics block: adapts from 2 cols to 3/4 based on available width */
@@ -753,11 +774,18 @@ h1 {
 
 /* Surfaces (cards) */
 .card {
-  background: var(--md-sys-color-surface-container);
+  background-color: var(--md-sys-color-surface-container);
+  background-image: linear-gradient(
+    180deg,
+    color-mix(in oklab, white 4%, transparent) 0%,
+    transparent 32%
+  );
   border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--md-sys-shape-corner-large);
   padding: 12px;
-  box-shadow: var(--md-elevation-1);
+  box-shadow:
+    var(--md-elevation-1),
+    inset 0 1px 0 color-mix(in oklab, white 7%, transparent);
 }
 
 .sparkline {
@@ -822,7 +850,10 @@ select:hover {
   cursor: pointer;
   color: var(--md-sys-color-on-surface);
   background: transparent;
-  transition: transform 120ms ease, filter 120ms ease, background 120ms ease, border-color 120ms ease;
+  position: relative;
+  overflow: clip;
+  isolation: isolate;
+  transition: transform 120ms ease, filter 120ms ease, background 120ms ease, border-color 120ms ease, box-shadow 160ms ease;
 
   /* Icon + label layout. Every .btn may contain a .btn-icon followed by a
      .btn-label span. Bare-text buttons still work because the flex box is
@@ -851,7 +882,7 @@ select:hover {
 }
 
 .btn.filled {
-  background: var(--md-sys-color-primary);
+  background-color: var(--md-sys-color-primary);
   color: var(--md-sys-color-on-primary);
   box-shadow: var(--md-elevation-1);
 }
@@ -859,7 +890,7 @@ select:hover {
 .btn.filled:hover { filter: brightness(1.05); }
 
 .btn.tonal {
-  background: var(--md-sys-color-secondary-container);
+  background-color: var(--md-sys-color-secondary-container);
   color: var(--md-sys-color-on-secondary-container);
   box-shadow: var(--md-elevation-1);
 }
@@ -884,12 +915,63 @@ select:hover {
 }
 
 .btn.error {
-  background: var(--md-sys-color-error-container);
+  background-color: var(--md-sys-color-error-container);
   color: var(--md-sys-color-on-error-container);
   box-shadow: var(--md-elevation-1);
 }
 
 .btn.error:hover { filter: brightness(1.03); }
+
+/* Material "lit from above" gloss on solid-surface buttons: a soft
+   highlight gradient fades into the body color, so the button reads as
+   a glass-coated pill rather than a flat fill. */
+.btn.filled,
+.btn.tonal,
+.btn.error {
+  background-image: linear-gradient(
+    180deg,
+    color-mix(in oklab, white 16%, transparent) 0%,
+    color-mix(in oklab, white 3%, transparent) 45%,
+    transparent 100%
+  );
+}
+
+/* Hover shine: a diagonal specular sweep traverses the button once. */
+.btn.filled::after,
+.btn.tonal::after,
+.btn.error::after,
+.segmented .btn.is-selected::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(
+    110deg,
+    transparent 38%,
+    color-mix(in oklab, white 28%, transparent) 50%,
+    transparent 62%
+  );
+  transform: translateX(-130%);
+  transition: transform 700ms cubic-bezier(0.22, 1, 0.36, 1);
+  z-index: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .btn.filled:hover::after,
+  .btn.tonal:hover::after,
+  .btn.error:hover::after,
+  .segmented .btn.is-selected:hover::after { transform: translateX(130%); }
+}
+
+/* Press depression: pairs with the existing translateY + scale to sell
+   the "pushed in" tactile response. */
+.btn.filled:active,
+.btn.tonal:active,
+.btn.error:active {
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.24), var(--md-elevation-1);
+  filter: brightness(0.96);
+}
 
 /* Segmented buttons (for Mode) */
 .segmented {


### PR DESCRIPTION
Sticky metrics grid was eating ~140px of sidebar height. Replaced with a ~40px chip strip. Same always-on metrics, a third of the height.

Capacity HUD reflows horizontally: .capRow is an auto-fit grid with display:contents on the group wrappers, a caphud container query gives Refill span-2 when the HUD is wide and collapses labels to icons under 260px. Refill promoted to btn filled to keep its rank after the reflow.

Modern-CSS polish: selected-card conic halo via :has(#btnUpgrade:not(:disabled)) no JS touch; scroll-driven card reveal via animation-timeline: view(); text-wrap: balance on headings; startViewTransition crossfade on tab change gated !IS_E2E. Reduced-motion honoured throughout.

Dropped from plan: @container scroll-state block .sideHeader sits outside the scrolling .sideBody in the current DOM so it never gets "stuck". The chip strip already solves the height problem. light-dark() consolidation deferred to a follow-up PR.

Verification: vitest 138/138, build, playwright e2e 10/10 green.