### PR TITLE
Bump version to 0.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-survival-android",
-  "version": "0.2.1",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app-survival-android",
-      "version": "0.2.1",
+      "version": "0.3.3",
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "typescript": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app-survival-android",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "scripts": {
     "dev": "node ./node_modules/vite/bin/vite.js",


### PR DESCRIPTION
Release cut for v0.3.3. Changes since v0.3.2 (all merged to main):

- Move Backlog to bottom-right canvas HUD, mirror of Capacity (#92)
- Compact sticky header, reflowing Capacity HUD, view-transition polish (#93)
- Fix capacity button label smash; material gloss + glass HUDs (part of #93)
- Cloudflare Workers Static Assets config + hosting split docs

Tag and GitHub release go up after this merges.