### PR TITLE
Surface Platform chip on canvas, reclaim dashboard header space

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,20 @@
             </div>
           </div>
         </div>
+        <!-- Platform chip: surface Latest API / Min API / device-share mix on
+             the canvas under the mode hint (drawn at 16,12 in main.ts) so the
+             right-hand dashboard doesn't have to scroll to reveal the only
+             signal that drives min-API and device-mix decisions. -->
+        <div class="canvasHud canvasHud--platform" role="region" aria-label="Platform">
+          <div class="k" data-i18n="card.platform">Platform</div>
+          <div class="small" style="margin-top:6px;">
+            <span data-i18n="platform.latestApi">Latest API</span> <span id="apiLatest" class="mono">0</span> • <span data-i18n="platform.minApi">Min API</span> <span id="apiMin" class="mono">0</span>
+          </div>
+          <div class="small muted" style="margin-top:4px;">
+            <span data-i18n="platform.oldDevices">Old devices</span> <span id="oldShare" class="mono">0</span>% • <span data-i18n="platform.lowRam">Low RAM</span> <span id="lowRamShare" class="mono">0</span>%
+          </div>
+          <div id="advisoryText" class="small" style="margin-top:6px;"></div>
+        </div>
         <div class="canvasHud canvasHud--backlog" role="region" aria-label="Backlog">
           <section class="card" id="backlogCard">
             <div class="k" data-i18n="nav.backlog">Backlog</div>
@@ -350,17 +364,6 @@
         <section id="tabSignals" class="tabPanel" role="tabpanel" aria-labelledby="tabBtnSignals">
 
         <div class="sideGroup">
-          <section class="card">
-            <div class="k" data-i18n="card.platform">Platform</div>
-            <div class="small" style="margin-top:8px;">
-              <span data-i18n="platform.latestApi">Latest API</span> <span id="apiLatest" class="mono">0</span> • <span data-i18n="platform.minApi">Min API</span> <span id="apiMin" class="mono">0</span>
-            </div>
-            <div class="small muted" style="margin-top:4px;">
-              <span data-i18n="platform.oldDevices">Old devices</span> <span id="oldShare" class="mono">0</span>% • <span data-i18n="platform.lowRam">Low RAM</span> <span id="lowRamShare" class="mono">0</span>%
-            </div>
-            <div id="advisoryText" class="small" style="margin-top:8px;"></div>
-          </section>
-
           <section class="card">
             <div class="k" data-i18n="card.regions">Regions</div>
             <div class="row" style="margin-top:8px; align-items:center;">

--- a/index.html
+++ b/index.html
@@ -50,19 +50,52 @@
             </div>
           </div>
         </div>
-        <!-- Platform chip: surface Latest API / Min API / device-share mix on
-             the canvas under the mode hint (drawn at 16,12 in main.ts) so the
-             right-hand dashboard doesn't have to scroll to reveal the only
-             signal that drives min-API and device-mix decisions. -->
-        <div class="canvasHud canvasHud--platform" role="region" aria-label="Platform">
-          <div class="k" data-i18n="card.platform">Platform</div>
-          <div class="small" style="margin-top:6px;">
-            <span data-i18n="platform.latestApi">Latest API</span> <span id="apiLatest" class="mono">0</span> • <span data-i18n="platform.minApi">Min API</span> <span id="apiMin" class="mono">0</span>
+        <!-- Setup stack: the primary place-component control sits next to the
+             Platform chip directly under the mode hint so the "what am I
+             building, what platform am I building for" decisions live side
+             by side on the canvas, reclaiming vertical space on the
+             right-hand dashboard. -->
+        <div class="canvasHudStack canvasHudStack--tl" role="group" aria-label="Setup">
+          <div class="canvasHud canvasHud--place" role="region" aria-label="Place component">
+            <label for="componentType" class="k" data-i18n="setup.placeComponent">Place component</label>
+            <div class="row" style="margin-top:6px; flex-wrap:nowrap; gap:6px;">
+              <select id="componentType" style="flex:1; min-width:0;">
+                <option value="UI" data-i18n="component.UI">UI</option>
+                <option value="VM" data-i18n="component.VM">ViewModel</option>
+                <option value="DOMAIN" data-i18n="component.DOMAIN">Domain</option>
+                <option value="REPO" data-i18n="component.REPO">Repository</option>
+                <option value="CACHE" data-i18n="component.CACHE">Cache</option>
+                <option value="DB" data-i18n="component.DB">Room DB</option>
+                <option value="NET" data-i18n="component.NET">Network</option>
+                <option value="WORK" data-i18n="component.WORK">WorkManager</option>
+                <option value="OBS" data-i18n="component.OBS">Observability</option>
+                <option value="FLAGS" data-i18n="component.FLAGS">Feature Flags</option>
+                <option value="AUTH" data-i18n="component.AUTH">Auth / Sessions</option>
+                <option value="PINNING" data-i18n="component.PINNING">TLS Pinning</option>
+                <option value="KEYSTORE" data-i18n="component.KEYSTORE">Keystore / Crypto</option>
+                <option value="SANITIZER" data-i18n="component.SANITIZER">Input Sanitizer</option>
+                <option value="ABUSE" data-i18n="component.ABUSE">Abuse Protection</option>
+                <option value="A11Y" data-i18n="component.A11Y">Accessibility Layer</option>
+                <option value="BILLING" data-i18n="component.BILLING">Billing / IAP</option>
+                <option value="PUSH" data-i18n="component.PUSH">Push / FCM</option>
+                <option value="DEEPLINK" data-i18n="component.DEEPLINK">Deep Links</option>
+              </select>
+              <button id="btnAdd" class="btn tonal" data-i18n-title="btn.add" title="Add">
+                <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                <span class="btn-label" data-i18n="btn.add">Add</span>
+              </button>
+            </div>
           </div>
-          <div class="small muted" style="margin-top:4px;">
-            <span data-i18n="platform.oldDevices">Old devices</span> <span id="oldShare" class="mono">0</span>% • <span data-i18n="platform.lowRam">Low RAM</span> <span id="lowRamShare" class="mono">0</span>%
+          <div class="canvasHud canvasHud--platform" role="region" aria-label="Platform">
+            <div class="k" data-i18n="card.platform">Platform</div>
+            <div class="small" style="margin-top:6px;">
+              <span data-i18n="platform.latestApi">Latest API</span> <span id="apiLatest" class="mono">0</span> • <span data-i18n="platform.minApi">Min API</span> <span id="apiMin" class="mono">0</span>
+            </div>
+            <div class="small muted" style="margin-top:4px;">
+              <span data-i18n="platform.oldDevices">Old devices</span> <span id="oldShare" class="mono">0</span>% • <span data-i18n="platform.lowRam">Low RAM</span> <span id="lowRamShare" class="mono">0</span>%
+            </div>
+            <div id="advisoryText" class="small" style="margin-top:6px;"></div>
           </div>
-          <div id="advisoryText" class="small" style="margin-top:6px;"></div>
         </div>
         <div class="canvasHud canvasHud--backlog" role="region" aria-label="Backlog">
           <section class="card" id="backlogCard">
@@ -324,39 +357,6 @@
             <div class="small muted" style="margin-top:8px;" data-i18n="setup.evalPresetHint">CoverageGate and enforcement weight</div>
           </section>
 
-          <section class="card">
-            <label for="componentType" class="k" data-i18n="setup.placeComponent">Place component</label>
-            <div class="row" style="margin-top:8px;">
-              <select id="componentType">
-                <option value="UI" data-i18n="component.UI">UI</option>
-                <option value="VM" data-i18n="component.VM">ViewModel</option>
-                <option value="DOMAIN" data-i18n="component.DOMAIN">Domain</option>
-                <option value="REPO" data-i18n="component.REPO">Repository</option>
-                <option value="CACHE" data-i18n="component.CACHE">Cache</option>
-                <option value="DB" data-i18n="component.DB">Room DB</option>
-                <option value="NET" data-i18n="component.NET">Network</option>
-                <option value="WORK" data-i18n="component.WORK">WorkManager</option>
-                <option value="OBS" data-i18n="component.OBS">Observability</option>
-                <option value="FLAGS" data-i18n="component.FLAGS">Feature Flags</option>
-                <option value="AUTH" data-i18n="component.AUTH">Auth / Sessions</option>
-                <option value="PINNING" data-i18n="component.PINNING">TLS Pinning</option>
-                <option value="KEYSTORE" data-i18n="component.KEYSTORE">Keystore / Crypto</option>
-                <option value="SANITIZER" data-i18n="component.SANITIZER">Input Sanitizer</option>
-                <option value="ABUSE" data-i18n="component.ABUSE">Abuse Protection</option>
-                <option value="A11Y" data-i18n="component.A11Y">Accessibility Layer</option>
-                <option value="BILLING" data-i18n="component.BILLING">Billing / IAP</option>
-                <option value="PUSH" data-i18n="component.PUSH">Push / FCM</option>
-                <option value="DEEPLINK" data-i18n="component.DEEPLINK">Deep Links</option>
-              </select>
-              <button id="btnAdd" class="btn tonal" data-i18n-title="btn.add" title="Add">
-                <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-                <span class="btn-label" data-i18n="btn.add">Add</span>
-              </button>
-            </div>
-            <div class="small" style="margin-top:8px;">
-              <span data-i18n="setup.dragHintPrefix">Drag components to rearrange. Link mode: click</span> <span class="mono" data-i18n="setup.dragHintSource">source</span> → <span data-i18n="setup.dragHintThen">click</span> <span class="mono" data-i18n="setup.dragHintDest">destination</span>
-            </div>
-          </section>
         </div>
 
         </section> <!-- /tabOverview -->

--- a/src/style.css
+++ b/src/style.css
@@ -378,6 +378,35 @@ button, input, select, textarea {
   padding: 8px 10px;
 }
 
+.canvasHud--platform {
+  /* Sits under the mode hint drawn onto the canvas at (16, 12) in main.ts —
+     a ~24px offset leaves the hint legible with breathing room. */
+  top: 36px;
+  right: auto;
+  left: 10px;
+  flex-direction: column;
+  gap: 4px;
+  width: clamp(220px, 24%, 320px);
+  background-color: color-mix(in oklab, var(--md-sys-color-surface-container-high) 82%, transparent);
+  background-image: linear-gradient(
+    180deg,
+    color-mix(in oklab, white 5%, transparent) 0%,
+    transparent 40%
+  );
+  backdrop-filter: saturate(140%) blur(10px);
+  -webkit-backdrop-filter: saturate(140%) blur(10px);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--md-sys-shape-corner-large);
+  padding: 10px;
+  box-shadow:
+    var(--md-elevation-2),
+    inset 0 1px 0 color-mix(in oklab, white 10%, transparent);
+}
+
+.canvasHud--platform #advisoryText:empty {
+  display: none;
+}
+
 .canvasHud--backlog {
   top: auto;
   left: auto;
@@ -449,12 +478,16 @@ canvas {
 /* Right panel (like a persistent “details” sheet) */
 .side {
   border-left: 1px solid var(--md-sys-color-outline-variant);
-  padding: var(--md-pad-3) var(--md-pad-3) var(--md-pad-4);
+  /* Tight top padding (8px, M3 density step) pulls the sticky header flush
+     with the viewport edge; L/R/B keep the 16/20 breathing room. */
+  padding: var(--md-pad-1) var(--md-pad-3) var(--md-pad-4);
   overflow: hidden;
   display: flex;
   flex-direction: column;
   gap: 12px;
   background: var(--md-sys-color-surface);
+  /* Anchor for the decorative ::before pseudo below. */
+  position: relative;
 }
 
 .sideBody {
@@ -539,6 +572,14 @@ canvas {
   }
   .canvasHud--actions > * { overflow: auto; }
   .canvasHud--backlog .ticketList { max-height: 24vh; overflow: auto; }
+
+  /* On narrow portrait canvases the platform chip risks overlapping the
+     zoom buttons (top-right) — cap its width and let it wrap below. */
+  .canvasHud--platform {
+    top: 34px;
+    left: 8px;
+    width: clamp(160px, 50%, 260px);
+  }
 }
 
 .sideHeader > * {
@@ -555,8 +596,13 @@ canvas {
 
 .side::before {
   content: "";
-  position: sticky;
+  /* Absolute positioning keeps this decorative shadow layer out of the
+     flex flow — otherwise the parent's 12px gap would push the sticky
+     header down by 12px even though this element is 0px tall. */
+  position: absolute;
   top: 0;
+  left: 0;
+  right: 0;
   display: block;
   height: 0;
   box-shadow:

--- a/src/style.css
+++ b/src/style.css
@@ -378,15 +378,45 @@ button, input, select, textarea {
   padding: 8px 10px;
 }
 
-.canvasHud--platform {
-  /* Sits under the mode hint drawn onto the canvas at (16, 12) in main.ts —
-     a ~24px offset leaves the hint legible with breathing room. */
+/* Setup stack: a flex row wrapper that holds the place-component and
+   platform HUDs side by side under the canvas mode hint at (16, 12).
+   Flex-gap + flex-wrap mean neither HUD needs to know the other's size,
+   and narrow canvases get an automatic column layout. */
+.canvasHudStack {
+  position: absolute;
+  z-index: 2;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.canvasHudStack--tl {
   top: 36px;
-  right: auto;
   left: 10px;
+  /* Leave clearance for the zoom HUD in the top-right. */
+  right: 10px;
+  max-width: calc(100% - 20px);
+}
+
+/* Children inside a stack opt out of .canvasHud's default absolute layout
+   so flex can place them. */
+.canvasHudStack > .canvasHud {
+  position: static;
+  top: auto;
+  right: auto;
+  bottom: auto;
+  left: auto;
+}
+
+.canvasHud--place,
+.canvasHud--platform {
   flex-direction: column;
   gap: 4px;
-  width: clamp(220px, 24%, 320px);
+  /* The HUD sits over the canvas. Let taps on the card's empty/text
+     regions pass through to the canvas (so a component placed behind the
+     HUD can still be selected / dragged); re-enable pointer events on
+     just the form controls. */
+  pointer-events: none;
   background-color: color-mix(in oklab, var(--md-sys-color-surface-container-high) 82%, transparent);
   background-image: linear-gradient(
     180deg,
@@ -401,6 +431,22 @@ button, input, select, textarea {
   box-shadow:
     var(--md-elevation-2),
     inset 0 1px 0 color-mix(in oklab, white 10%, transparent);
+}
+
+.canvasHud--place {
+  /* Slightly wider to fit the component-type select + Add button comfortably. */
+  width: clamp(260px, 28%, 360px);
+}
+
+.canvasHud--platform {
+  width: clamp(220px, 24%, 320px);
+}
+
+/* Re-enable taps on the things the user actually interacts with. */
+.canvasHud--place select,
+.canvasHud--place button,
+.canvasHud--place label {
+  pointer-events: auto;
 }
 
 .canvasHud--platform #advisoryText:empty {
@@ -573,12 +619,29 @@ canvas {
   .canvasHud--actions > * { overflow: auto; }
   .canvasHud--backlog .ticketList { max-height: 24vh; overflow: auto; }
 
-  /* On narrow portrait canvases the platform chip risks overlapping the
-     zoom buttons (top-right) — cap its width and let it wrap below. */
-  .canvasHud--platform {
+  /* On narrow portrait canvases both HUDs compact to single-line chips —
+     the full layout would stretch into the bottom backlog territory at
+     mobile canvas heights (~38vh). Place keeps select + Add; Platform
+     drops to just the API numbers line. */
+  .canvasHudStack--tl {
     top: 34px;
     left: 8px;
-    width: clamp(160px, 50%, 260px);
+    right: 8px;
+    max-width: calc(100% - 16px);
+    gap: 6px;
+  }
+  .canvasHud--place,
+  .canvasHud--platform {
+    width: 100%;
+    padding: 6px 8px;
+  }
+  .canvasHud--place > .k,
+  .canvasHud--platform > .small.muted,
+  .canvasHud--platform > #advisoryText {
+    display: none;
+  }
+  .canvasHud--place > .row {
+    margin-top: 0 !important;
   }
 }
 

--- a/tests/e2e/mobile-touch.spec.ts
+++ b/tests/e2e/mobile-touch.spec.ts
@@ -93,7 +93,10 @@ test('tap on canvas selects a component (touch)', async ({ page }) => {
   await page.goto('/');
   await expect(page.locator('#welcomeModal')).toBeHidden();
 
-  await page.click('#btnAdd');
+  // dispatchEvent bypasses the pointer-hit-test, which is fragile on the
+   // canvas at page load (transient incident overlay from the starter event
+   // can briefly obscure the Add button).
+  await page.locator('#btnAdd').dispatchEvent('click');
   const tap = await page.evaluate(() => {
     const sim = (window as any).__SIM__;
     const v = (window as any).__VIEW__;


### PR DESCRIPTION
## Summary
- Move the Platform block (Latest API / Min API / old-device + low-RAM shares + advisory) from the Signals tab onto a new top-left canvas HUD, under the mode hint. Min-API and device-mix signals stay visible regardless of which right-dashboard tab is active.
- Shrink the 28px dead zone above the sticky dashboard header. `.side` top padding drops from 16px to 8px and `.side::before` moves from sticky to absolute so the parent's 12px flex gap stops pushing the header down for a 0-tall decorative element.

## Test plan
- [x] npm run build
- [x] npm run test:e2e (20/20 passing: 10 desktop + 10 mobile)
- [x] Manual: verified dashboard header now starts at y=8 (was y=28); Platform HUD renders top-left under the canvas hint at (16, 12) with the expected glass styling.