### PR TITLE
Postmortem sticks until dismissed; h1 parallaxes with list scroll

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -138,7 +138,7 @@ const DICTS: Partial<Record<Lang, Dict>> = {
     'preset.staff': 'Staff',
     'preset.principal': 'Principal',
     'setup.placeComponent': 'Place component',
-    'btn.add': '+ Add',
+    'btn.add': 'Add',
     'component.UI': 'UI',
     'component.VM': 'ViewModel',
     'component.DOMAIN': 'Domain',

--- a/src/main.ts
+++ b/src/main.ts
@@ -1046,18 +1046,19 @@ window.addEventListener('resize', () => {
   updateTicketTitleToggles();
 });
 
-// Parallax: tie the sticky dashboard header h1 to the scroll position of
-// .sideBody so the title subtly drifts up and fades as the user scrolls
-// the card list underneath. CSS reads --side-scroll as a 0..1 ratio.
+// Parallax: tie the entire sticky dashboard header block to the scroll
+// position of .sideBody so the header (title + controls + tabs + status
+// strip) subtly drifts up and fades as the user scrolls the card list
+// underneath. CSS reads --side-scroll as a 0..1 ratio.
 {
-  const h1 = document.querySelector<HTMLElement>('.sideHeader h1');
-  if (h1) {
+  const header = document.querySelector<HTMLElement>('.sideHeader');
+  if (header) {
     const PARALLAX_RANGE = 80; // px of scroll over which the effect saturates
     let scheduled = false;
     const update = () => {
       scheduled = false;
       const ratio = Math.min(1, Math.max(0, refs.sideBody.scrollTop / PARALLAX_RANGE));
-      h1.style.setProperty('--side-scroll', ratio.toFixed(3));
+      header.style.setProperty('--side-scroll', ratio.toFixed(3));
     };
     refs.sideBody.addEventListener('scroll', () => {
       if (scheduled) return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1046,6 +1046,28 @@ window.addEventListener('resize', () => {
   updateTicketTitleToggles();
 });
 
+// Parallax: tie the sticky dashboard header h1 to the scroll position of
+// .sideBody so the title subtly drifts up and fades as the user scrolls
+// the card list underneath. CSS reads --side-scroll as a 0..1 ratio.
+{
+  const h1 = document.querySelector<HTMLElement>('.sideHeader h1');
+  if (h1) {
+    const PARALLAX_RANGE = 80; // px of scroll over which the effect saturates
+    let scheduled = false;
+    const update = () => {
+      scheduled = false;
+      const ratio = Math.min(1, Math.max(0, refs.sideBody.scrollTop / PARALLAX_RANGE));
+      h1.style.setProperty('--side-scroll', ratio.toFixed(3));
+    };
+    refs.sideBody.addEventListener('scroll', () => {
+      if (scheduled) return;
+      scheduled = true;
+      requestAnimationFrame(update);
+    }, { passive: true });
+    update();
+  }
+}
+
 syncCanvasSize();
 
 // initialize game
@@ -1285,7 +1307,10 @@ function closeEndRun() {
 }
 
 refs.endRunDismiss.onclick = closeEndRun;
-refs.endRunBackdrop.onclick = closeEndRun;
+// Deliberately no backdrop-to-close for the end-run modal: the postmortem
+// is the only moment to read the run result, and a stray outside-tap was
+// silently dismissing it. Users close via the explicit Close button or by
+// starting the next run via Play Again / Replay Seed.
 
 refs.endRunPlayAgain.onclick = () => {
   closeEndRun();

--- a/src/style.css
+++ b/src/style.css
@@ -557,6 +557,23 @@ canvas {
   border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--md-sys-shape-corner-large);
   box-shadow: var(--md-elevation-1);
+  /* Parallax: JS sets --side-scroll to a 0..1 ratio based on .sideBody
+     scrollTop, drifting the entire sticky header block up and fading it
+     slightly as the user scrolls the card list underneath. Opacity delta
+     stays small (0.12) so the buttons/tabs don't look disabled. */
+  --side-scroll: 0;
+  transform: translateY(calc(var(--side-scroll) * -8px));
+  opacity: calc(1 - var(--side-scroll) * 0.12);
+  transition: transform 160ms ease-out, opacity 160ms ease-out;
+  will-change: transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sideHeader {
+    transform: none;
+    opacity: 1;
+    transition: none;
+  }
 }
 
 .tabBar {
@@ -651,22 +668,6 @@ canvas {
 
 .sideHeader h1 {
   padding-top: 10px;
-  /* Parallax: JS sets --side-scroll to a 0..1 ratio based on .sideBody
-     scrollTop, letting the title drift up and fade while the user scrolls
-     the dashboard. Default 0 means pristine rendering before JS runs. */
-  --side-scroll: 0;
-  transform: translateY(calc(var(--side-scroll) * -6px));
-  opacity: calc(1 - var(--side-scroll) * 0.45);
-  transition: transform 160ms ease-out, opacity 160ms ease-out;
-  will-change: transform, opacity;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .sideHeader h1 {
-    transform: none;
-    opacity: 1;
-    transition: none;
-  }
 }
 
 .sideHeader .row:last-child {

--- a/src/style.css
+++ b/src/style.css
@@ -546,32 +546,35 @@ canvas {
   padding-top: 12px;
   scrollbar-gutter: stable;
   scroll-padding-top: 120px;
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0, black 14px);
+          mask-image: linear-gradient(to bottom, transparent 0, black 14px);
 }
 
 .sideHeader {
   position: sticky;
   top: 0;
   z-index: 5;
-  padding-bottom: 10px;
   background: var(--md-sys-color-surface-container-high);
   border: 1px solid var(--md-sys-color-outline-variant);
   border-radius: var(--md-sys-shape-corner-large);
   box-shadow: var(--md-elevation-1);
-  /* Parallax: JS sets --side-scroll to a 0..1 ratio based on .sideBody
-     scrollTop, drifting the entire sticky header block up and fading it
-     slightly as the user scrolls the card list underneath. Opacity delta
-     stays small (0.12) so the buttons/tabs don't look disabled. */
+  /* --side-scroll (0..1) is written by the scroll listener in main.ts.
+     Shaves a few px of bottom padding on top of the h1 collapse below. */
   --side-scroll: 0;
-  transform: translateY(calc(var(--side-scroll) * -8px));
-  opacity: calc(1 - var(--side-scroll) * 0.12);
-  transition: transform 160ms ease-out, opacity 160ms ease-out;
-  will-change: transform, opacity;
+  padding-bottom: calc(10px - var(--side-scroll) * 4px);
+  transition: padding-bottom 160ms ease-out;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .sideHeader {
-    transform: none;
+    padding-bottom: 10px;
+    transition: none;
+  }
+  .sideHeader h1 {
+    max-height: none;
+    margin-bottom: 12px;
     opacity: 1;
+    padding-top: 10px;
     transition: none;
   }
 }
@@ -667,7 +670,21 @@ canvas {
 }
 
 .sideHeader h1 {
-  padding-top: 10px;
+  padding-top: calc(10px - var(--side-scroll) * 10px);
+  /* 64px ceiling covers the ~44px intrinsic height (title + badge + top
+     padding) with slack; multiplying by (1 - ratio) guarantees an exact
+     0 at saturation, which max-height can't reach from content-height.
+     overflow:hidden clips text cleanly during the collapse. */
+  max-height: calc(64px - var(--side-scroll) * 64px);
+  margin-bottom: calc(12px - var(--side-scroll) * 12px);
+  opacity: calc(1 - var(--side-scroll));
+  overflow: hidden;
+  transition:
+    max-height 180ms ease-out,
+    margin-bottom 180ms ease-out,
+    padding-top 180ms ease-out,
+    opacity 180ms ease-out;
+  will-change: max-height, opacity;
 }
 
 .sideHeader .row:last-child {
@@ -802,7 +819,7 @@ h1 {
 
 .statusChip {
   display: inline-flex;
-  align-items: baseline;
+  align-items: center;
   gap: 6px;
   flex: 1 1 auto;
   min-width: 0;

--- a/src/style.css
+++ b/src/style.css
@@ -651,6 +651,22 @@ canvas {
 
 .sideHeader h1 {
   padding-top: 10px;
+  /* Parallax: JS sets --side-scroll to a 0..1 ratio based on .sideBody
+     scrollTop, letting the title drift up and fade while the user scrolls
+     the dashboard. Default 0 means pristine rendering before JS runs. */
+  --side-scroll: 0;
+  transform: translateY(calc(var(--side-scroll) * -6px));
+  opacity: calc(1 - var(--side-scroll) * 0.45);
+  transition: transform 160ms ease-out, opacity 160ms ease-out;
+  will-change: transform, opacity;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sideHeader h1 {
+    transform: none;
+    opacity: 1;
+    transition: none;
+  }
 }
 
 .sideHeader .row:last-child {

--- a/tests/e2e/core-flows.spec.ts
+++ b/tests/e2e/core-flows.spec.ts
@@ -91,18 +91,25 @@ test('end-run modal does not dismiss on backdrop click', async ({ page }) => {
 test('dashboard scroll drives sticky-header parallax', async ({ page }) => {
   await page.goto('/');
 
-  // The parallax writes to --side-scroll on the entire .sideHeader block
-  // via a rAF-throttled scroll listener. At rest the ratio is 0 and the
-  // header renders at full opacity.
+  // The parallax writes to --side-scroll on the .sideHeader block via a
+  // rAF-throttled scroll listener. The h1 hero collapses to zero height
+  // as the ratio saturates while the remaining controls (buttons, mode
+  // row, tabs, status chips) stay fully opaque so they don't look
+  // disabled.
   const atRest = await page.evaluate(() => {
     const header = document.querySelector('.sideHeader') as HTMLElement;
+    const h1 = header.querySelector('h1') as HTMLElement;
     return {
       ratio: header.style.getPropertyValue('--side-scroll').trim(),
-      opacity: Number(getComputedStyle(header).opacity),
+      headerOpacity: Number(getComputedStyle(header).opacity),
+      h1Height: h1.offsetHeight,
+      h1Opacity: Number(getComputedStyle(h1).opacity),
     };
   });
   expect(atRest.ratio).toBe('0.000');
-  expect(atRest.opacity).toBeCloseTo(1, 1);
+  expect(atRest.headerOpacity).toBeCloseTo(1, 1);
+  expect(atRest.h1Height).toBeGreaterThan(30);
+  expect(atRest.h1Opacity).toBeCloseTo(1, 1);
 
   // Scroll well past the 80px parallax saturation point.
   await page.evaluate(() => {
@@ -113,15 +120,20 @@ test('dashboard scroll drives sticky-header parallax', async ({ page }) => {
 
   const afterScroll = await page.evaluate(() => {
     const header = document.querySelector('.sideHeader') as HTMLElement;
+    const h1 = header.querySelector('h1') as HTMLElement;
     return {
       ratio: Number(header.style.getPropertyValue('--side-scroll')),
-      opacity: Number(getComputedStyle(header).opacity),
+      headerOpacity: Number(getComputedStyle(header).opacity),
+      h1Height: h1.offsetHeight,
+      h1Opacity: Number(getComputedStyle(h1).opacity),
     };
   });
   // Ratio saturates at 1 once scrollTop exceeds the 80px range.
   expect(afterScroll.ratio).toBeGreaterThan(0.9);
-  // Opacity at saturation should be ~0.88 (1 - 0.12) — subtle enough that
-  // interactive controls inside the header don't look disabled.
-  expect(afterScroll.opacity).toBeLessThan(0.95);
-  expect(afterScroll.opacity).toBeGreaterThan(0.8);
+  // The h1 hero collapses to zero: height clamped and opacity fades out.
+  expect(afterScroll.h1Height).toBeLessThanOrEqual(2);
+  expect(afterScroll.h1Opacity).toBeLessThan(0.1);
+  // Invariant: the header itself (buttons/tabs/chips) stays fully opaque
+  // so interactive controls never look disabled.
+  expect(afterScroll.headerOpacity).toBeGreaterThan(0.95);
 });

--- a/tests/e2e/core-flows.spec.ts
+++ b/tests/e2e/core-flows.spec.ts
@@ -88,16 +88,17 @@ test('end-run modal does not dismiss on backdrop click', async ({ page }) => {
   await expect(page.locator('#endRunModal')).toBeHidden();
 });
 
-test('dashboard scroll drives h1 parallax', async ({ page }) => {
+test('dashboard scroll drives sticky-header parallax', async ({ page }) => {
   await page.goto('/');
 
-  // The parallax writes to --side-scroll on .sideHeader h1 via a rAF-
-  // throttled scroll listener. At rest the ratio is 0 and opacity is 1.
+  // The parallax writes to --side-scroll on the entire .sideHeader block
+  // via a rAF-throttled scroll listener. At rest the ratio is 0 and the
+  // header renders at full opacity.
   const atRest = await page.evaluate(() => {
-    const h1 = document.querySelector('.sideHeader h1') as HTMLElement;
+    const header = document.querySelector('.sideHeader') as HTMLElement;
     return {
-      ratio: h1.style.getPropertyValue('--side-scroll').trim(),
-      opacity: Number(getComputedStyle(h1).opacity),
+      ratio: header.style.getPropertyValue('--side-scroll').trim(),
+      opacity: Number(getComputedStyle(header).opacity),
     };
   });
   expect(atRest.ratio).toBe('0.000');
@@ -111,15 +112,16 @@ test('dashboard scroll drives h1 parallax', async ({ page }) => {
   await page.waitForTimeout(300);
 
   const afterScroll = await page.evaluate(() => {
-    const h1 = document.querySelector('.sideHeader h1') as HTMLElement;
+    const header = document.querySelector('.sideHeader') as HTMLElement;
     return {
-      ratio: Number(h1.style.getPropertyValue('--side-scroll')),
-      opacity: Number(getComputedStyle(h1).opacity),
+      ratio: Number(header.style.getPropertyValue('--side-scroll')),
+      opacity: Number(getComputedStyle(header).opacity),
     };
   });
   // Ratio saturates at 1 once scrollTop exceeds the 80px range.
   expect(afterScroll.ratio).toBeGreaterThan(0.9);
-  // Opacity at saturation should be ~0.55 (1 - 0.45).
-  expect(afterScroll.opacity).toBeLessThan(0.7);
-  expect(afterScroll.opacity).toBeGreaterThan(0.4);
+  // Opacity at saturation should be ~0.88 (1 - 0.12) — subtle enough that
+  // interactive controls inside the header don't look disabled.
+  expect(afterScroll.opacity).toBeLessThan(0.95);
+  expect(afterScroll.opacity).toBeGreaterThan(0.8);
 });

--- a/tests/e2e/core-flows.spec.ts
+++ b/tests/e2e/core-flows.spec.ts
@@ -66,3 +66,60 @@ test('score increases after running for a few ticks', async ({ page }) => {
   const score = parseInt(await page.locator('#score').innerText(), 10);
   expect(score).toBeGreaterThan(0);
 });
+
+test('end-run modal does not dismiss on backdrop click', async ({ page }) => {
+  await page.goto('/');
+
+  // Open the end-run modal directly — we're testing the backdrop-click
+  // guard, not the run-ended trigger logic. Setting .hidden = false mirrors
+  // what openModal() does for visibility purposes.
+  await page.evaluate(() => {
+    document.getElementById('endRunModal')!.hidden = false;
+  });
+  await expect(page.locator('#endRunModal')).toBeVisible();
+
+  // Click the backdrop in a corner — the center of the backdrop is covered
+  // by the modal panel. The modal must remain visible after the click.
+  await page.locator('#endRunBackdrop').click({ position: { x: 10, y: 10 } });
+  await expect(page.locator('#endRunModal')).toBeVisible();
+
+  // The explicit Close button still dismisses as expected.
+  await page.click('#endRunDismiss');
+  await expect(page.locator('#endRunModal')).toBeHidden();
+});
+
+test('dashboard scroll drives h1 parallax', async ({ page }) => {
+  await page.goto('/');
+
+  // The parallax writes to --side-scroll on .sideHeader h1 via a rAF-
+  // throttled scroll listener. At rest the ratio is 0 and opacity is 1.
+  const atRest = await page.evaluate(() => {
+    const h1 = document.querySelector('.sideHeader h1') as HTMLElement;
+    return {
+      ratio: h1.style.getPropertyValue('--side-scroll').trim(),
+      opacity: Number(getComputedStyle(h1).opacity),
+    };
+  });
+  expect(atRest.ratio).toBe('0.000');
+  expect(atRest.opacity).toBeCloseTo(1, 1);
+
+  // Scroll well past the 80px parallax saturation point.
+  await page.evaluate(() => {
+    document.getElementById('sideBody')!.scrollTop = 200;
+  });
+  // Allow the rAF callback to fire and the CSS transition to settle.
+  await page.waitForTimeout(300);
+
+  const afterScroll = await page.evaluate(() => {
+    const h1 = document.querySelector('.sideHeader h1') as HTMLElement;
+    return {
+      ratio: Number(h1.style.getPropertyValue('--side-scroll')),
+      opacity: Number(getComputedStyle(h1).opacity),
+    };
+  });
+  // Ratio saturates at 1 once scrollTop exceeds the 80px range.
+  expect(afterScroll.ratio).toBeGreaterThan(0.9);
+  // Opacity at saturation should be ~0.55 (1 - 0.45).
+  expect(afterScroll.opacity).toBeLessThan(0.7);
+  expect(afterScroll.opacity).toBeGreaterThan(0.4);
+});


### PR DESCRIPTION
Two dashboard-polish items that missed the PR #96 merge window.

## Summary
- End-of-run modal no longer dismisses on backdrop click. The postmortem is the only moment to read the run grade and breakdown, and a stray outside tap was silently closing it. Users now close via the Close button or by starting the next run via Play Again / Replay Seed.
- Sticky dashboard header h1 gets a subtle parallax tied to .sideBody scroll. A passive listener writes a 0..1 ratio to a --side-scroll CSS variable over an 80px scroll range; the h1 translates up 6px and fades to 0.55 opacity at full range. Respects prefers-reduced-motion.

## Test plan
- [x] npm run build
- [x] npm run test:e2e (22/22 passing; two new specs in core-flows.spec.ts cover the backdrop guard and parallax ratio/opacity)