### PR TITLE
Collapse Backlog HUD to severity-summary drawer; move action row under status chips

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,10 +98,14 @@
           </div>
         </div>
         <div class="canvasHud canvasHud--backlog" role="region" aria-label="Backlog">
-          <section class="card" id="backlogCard">
-            <div class="k" data-i18n="nav.backlog">Backlog</div>
-            <div id="ticketList" class="ticketList" style="margin-top:10px;"></div>
-          </section>
+          <details class="card" id="backlogDetails">
+            <summary class="backlogSummary">
+              <span class="backlogSummary-k" data-i18n="nav.backlog">Backlog</span>
+              <span class="backlogSummary-chips" id="backlogSummaryChips" aria-hidden="true"></span>
+              <span class="backlogSummary-caret" aria-hidden="true">▸</span>
+            </summary>
+            <div id="ticketList" class="ticketList"></div>
+          </details>
         </div>
         <!-- Incident response: shown briefly when a new incident hits -->
         <div id="incidentOverlay" class="incidentOverlay" hidden aria-live="polite" aria-atomic="true">
@@ -125,26 +129,7 @@
         <div class="sideHeader">
           <h1><span data-i18n="app.title">App Survival: Android Release Night</span> <span class="badge" data-i18n="app.badge">M3 • TS + Vite</span></h1>
 
-          <div class="row">
-            <button id="btnStart" class="btn filled" data-i18n-title="btn.start" title="Start">
-              <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="6 3 20 12 6 21 6 3"/></svg>
-              <span class="btn-label" data-i18n="btn.start">Start</span>
-            </button>
-            <button id="btnPause" class="btn tonal" data-i18n-title="btn.pause" title="Pause">
-              <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="4" width="4" height="16" rx="1"/><rect x="14" y="4" width="4" height="16" rx="1"/></svg>
-              <span class="btn-label" data-i18n="btn.pause">Pause</span>
-            </button>
-            <button id="btnReset" class="btn outlined" data-i18n-title="btn.reset" title="Reset">
-              <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 3v5h5"/></svg>
-              <span class="btn-label" data-i18n="btn.reset">Reset</span>
-            </button>
-            <button id="btnProfile" class="btn outlined" data-i18n-title="btn.profileTitle" title="Profile & achievements">
-              <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>
-              <span class="btn-label" data-i18n="btn.profile">Profile</span>
-            </button>
-          </div>
-
-          <div class="row" style="margin-top:10px; align-items:center;">
+          <div class="row" style="align-items:center;">
             <span class="pill" id="modePill"><span data-i18n="mode.label">Mode:</span> <b data-i18n="mode.select">Select</b></span>
             <div class="row segmented" role="group" aria-label="Mode" style="margin-left:auto;">
               <button id="btnSelect" class="btn text is-selected" data-i18n-title="mode.select" title="Select">
@@ -189,6 +174,25 @@
               <span id="comboIndicator" class="pill pill-combo" hidden>COMBO x1</span>
             </div>
           </section>
+
+          <div class="row" style="margin-top:10px;">
+            <button id="btnStart" class="btn filled" data-i18n-title="btn.start" title="Start">
+              <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="6 3 20 12 6 21 6 3"/></svg>
+              <span class="btn-label" data-i18n="btn.start">Start</span>
+            </button>
+            <button id="btnPause" class="btn tonal" data-i18n-title="btn.pause" title="Pause">
+              <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="4" width="4" height="16" rx="1"/><rect x="14" y="4" width="4" height="16" rx="1"/></svg>
+              <span class="btn-label" data-i18n="btn.pause">Pause</span>
+            </button>
+            <button id="btnReset" class="btn outlined" data-i18n-title="btn.reset" title="Reset">
+              <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7L3 8"/><path d="M3 3v5h5"/></svg>
+              <span class="btn-label" data-i18n="btn.reset">Reset</span>
+            </button>
+            <button id="btnProfile" class="btn outlined" data-i18n-title="btn.profileTitle" title="Profile & achievements">
+              <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>
+              <span class="btn-label" data-i18n="btn.profile">Profile</span>
+            </button>
+          </div>
         </div>
 
         <div id="sideBody" class="sideBody">

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -218,6 +218,11 @@ const DICTS: Partial<Record<Lang, Dict>> = {
     'toast.noRoadmapTicket': 'No architecture debt ticket to refactor',
 
     'backlog.noTickets': 'No open tickets',
+    'backlog.summary.total': '{n} open',
+    'backlog.summary.deferred': '{n} deferred',
+    'backlog.open': 'Open backlog',
+    'backlog.close': 'Close backlog',
+    'ticket.more': 'More actions',
     'ticket.fix': 'Fix ({effort})',
     'ticket.need': 'Need {effort}',
     'ticket.defer': 'Defer',

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,6 +104,8 @@ type UIRefs = {
   regPressure: HTMLElement;
   regionList: HTMLElement;
   ticketList: HTMLElement;
+  backlogDetails: HTMLDetailsElement;
+  backlogSummaryChips: HTMLElement;
   reviewLog: HTMLElement;
   eventLog: HTMLElement;
 
@@ -341,9 +343,24 @@ function latestIncidentLine(eventsText: string): string {
   return eventsText.split('\n')[0] ?? '';
 }
 
+// Tracks whether the player has explicitly opened or closed the Backlog
+// drawer. Once they have, we stop fighting them with auto-open/close.
+let backlogUserToggled = false;
+let backlogAutoToggling = false;
+refs.backlogDetails.addEventListener('toggle', () => {
+  if (!backlogAutoToggling) backlogUserToggled = true;
+});
+function setBacklogOpen(open: boolean) {
+  if (refs.backlogDetails.open === open) return;
+  backlogAutoToggling = true;
+  refs.backlogDetails.open = open;
+  backlogAutoToggling = false;
+}
+
 function openBacklog() {
-  const el = document.getElementById('backlogCard') ?? refs.ticketList;
-  el.scrollIntoView({ behavior: IS_E2E ? 'auto' : 'smooth', block: 'start' });
+  backlogUserToggled = true;
+  setBacklogOpen(true);
+  refs.backlogDetails.scrollIntoView({ behavior: IS_E2E ? 'auto' : 'smooth', block: 'start' });
 }
 
 function quickTriage() {
@@ -625,6 +642,42 @@ function toast(msg: string) {
   }, 1100);
 }
 
+function closeAllTicketMenus(except?: HTMLElement) {
+  refs.ticketList.querySelectorAll<HTMLElement>('.ticketMenu').forEach((m) => {
+    if (m === except) return;
+    if (!m.hidden) m.hidden = true;
+  });
+  refs.ticketList.querySelectorAll<HTMLButtonElement>('button[data-overflow]').forEach((b) => {
+    b.setAttribute('aria-expanded', 'false');
+  });
+}
+
+document.addEventListener('click', (e) => {
+  const t = e.target as HTMLElement | null;
+  if (!t) return;
+  if (t.closest('.ticketMenu') || t.closest('.ticketOverflow')) return;
+  closeAllTicketMenus();
+});
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') closeAllTicketMenus();
+});
+
+function renderBacklogSummary(totals: { s3: number; s2: number; s1: number; s0: number; deferred: number; total: number }) {
+  const chipsEl = refs.backlogSummaryChips;
+  if (totals.total === 0) {
+    setHTML(chipsEl, `<span class="backlogSummary-empty small muted">${escapeHtml(t('backlog.noTickets'))}</span>`);
+    return;
+  }
+  const parts: string[] = [];
+  parts.push(`<span class="backlogSummary-total mono">${escapeHtml(t('backlog.summary.total', { n: totals.total }))}</span>`);
+  if (totals.s3 > 0) parts.push(`<span class="badge s3 backlogSummary-chip">S3×${totals.s3}</span>`);
+  if (totals.s2 > 0) parts.push(`<span class="badge s2 backlogSummary-chip">S2×${totals.s2}</span>`);
+  if (totals.s1 > 0) parts.push(`<span class="badge s1 backlogSummary-chip">S1×${totals.s1}</span>`);
+  if (totals.s0 > 0) parts.push(`<span class="badge s0 backlogSummary-chip">S0×${totals.s0}</span>`);
+  if (totals.deferred > 0) parts.push(`<span class="backlogSummary-chip backlogSummary-chip--muted mono small">${escapeHtml(t('backlog.summary.deferred', { n: totals.deferred }))}</span>`);
+  setHTML(chipsEl, parts.join(''));
+}
+
 function renderTicketTitleHtml(ticket: Ticket): string {
   const raw = (ticket.title ?? '').toString();
   if (ticket.kind === 'ARCHITECTURE_DEBT') {
@@ -828,6 +881,26 @@ function renderTickets() {
     if (bar) bar.setAttribute('aria-valuenow', String(Math.round(pct)));
   }
 
+  // Summary chips reflect the full ticket population, not the top-7 slice.
+  const allTickets = sim.getTickets();
+  const totals = { s3: 0, s2: 0, s1: 0, s0: 0, deferred: 0, total: allTickets.length };
+  for (const tk of allTickets) {
+    if (tk.deferred) totals.deferred++;
+    if (tk.severity === 3) totals.s3++;
+    else if (tk.severity === 2) totals.s2++;
+    else if (tk.severity === 1) totals.s1++;
+    else totals.s0++;
+  }
+  renderBacklogSummary(totals);
+
+  // Auto-open the drawer when tickets appear (so tests & players see them),
+  // auto-close when the backlog clears — respecting any manual toggle.
+  const incidentHot = document.documentElement.classList.contains('incident-hot');
+  if (!backlogUserToggled) {
+    if (totals.total > 0 || incidentHot) setBacklogOpen(true);
+    else setBacklogOpen(false);
+  }
+
   const nowMs = performance.now();
   // Include UI locale in the signature so a language switch re-renders ticket copy immediately.
   const langSig = getLanguage();
@@ -860,17 +933,21 @@ function renderTickets() {
     const sevClass = ticket.severity === 3 ? 'sev-critical' : ticket.severity === 2 ? 'sev-medium' : 'sev-low';
     const deferredClass = ticket.deferred ? 'is-deferred' : '';
     const reasonAttr = ticket.reason ? ` title="${escapeHtml(ticket.reason)}" data-reason="${escapeHtml(ticket.reason)}"` : '';
+    const sevBadgeClass = ticket.severity === 3 ? 's3' : ticket.severity === 2 ? 's2' : ticket.severity === 1 ? 's1' : 's0';
     return `
       <div class="ticket ${isArch ? 'is-arch' : ''} ${isExpanded ? 'is-expanded' : ''} ${sevClass} ${deferredClass}"${reasonAttr}>
         <div class="ticketMain">
-          <div class="ticketTitle"><span class="badge ${ticket.severity === 3 ? 's3' : ticket.severity === 2 ? 's2' : ticket.severity === 1 ? 's1' : 's0'}">${sev}</span> <span class="ticketTitleText" dir="auto">${titleHtml}</span></div>
+          <div class="ticketTitle"><span class="badge ${sevBadgeClass}">${sev}</span> <span class="ticketTitleText" dir="auto">${titleHtml}</span></div>
           ${!isArch ? `<button class="ticketTitleToggle" data-toggle-title="${ticket.id}" ${isExpanded ? '' : 'hidden'} aria-expanded="${isExpanded ? 'true' : 'false'}">${isExpanded ? t('ticket.collapseTitle') : t('ticket.expandTitle')}</button>` : ''}
-          <div class="ticketMeta"><span>${ticket.category}</span><span>${t('ticket.impact', { impact: ticket.impact })}</span><span>${t('ticket.age', { minutes: age })}</span>${ticket.deferred ? `<span class="badge">${t('ticket.deferred')}</span>` : ''}${ticket.reason ? `<span class="badge ticketReason" aria-label="Why it fired">ⓘ</span>` : ''}</div>
+          <div class="ticketMeta"><span class="ticketMetaChip">${ticket.category}</span><span class="ticketMetaChip">${t('ticket.impact', { impact: ticket.impact })}</span><span class="ticketMetaChip">${t('ticket.age', { minutes: age })}</span>${ticket.deferred ? `<span class="badge ticketMetaChip">${t('ticket.deferred')}</span>` : ''}${ticket.reason ? `<span class="badge ticketReason ticketMetaChip" aria-label="Why it fired">ⓘ</span>` : ''}</div>
         </div>
         <div class="ticketBtns">
           <button class="btn filled ${canFix ? '' : 'is-disabled'}" data-fix="${ticket.id}" ${canFix ? '' : 'disabled'}>${fixLabel}</button>
-          <button class="btn outlined" data-defer="${ticket.id}">${deferLabel}</button>
-          ${isArch ? `<button class="btn tonal" data-open-refactor="${ticket.id}">${t('ticket.refactorOptions')}</button>` : ''}
+          <button class="btn text ticketOverflow" data-overflow="${ticket.id}" aria-haspopup="menu" aria-expanded="false" aria-label="${t('ticket.more')}">⋯</button>
+        </div>
+        <div class="ticketMenu" role="menu" hidden>
+          <button class="btn outlined" role="menuitem" data-defer="${ticket.id}">${deferLabel}</button>
+          ${isArch ? `<button class="btn tonal" role="menuitem" data-open-refactor="${ticket.id}">${t('ticket.refactorOptions')}</button>` : ''}
         </div>
       </div>
     `;
@@ -894,6 +971,21 @@ function renderTickets() {
     btn.addEventListener('click', (e) => {
       const id = Number((e.currentTarget as HTMLElement).getAttribute('data-open-refactor'));
       openRefactor(id);
+    });
+  });
+
+  // Overflow (…) popover per ticket — holds Defer and (for arch) Refactor options.
+  refs.ticketList.querySelectorAll<HTMLButtonElement>('button[data-overflow]').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const b = e.currentTarget as HTMLButtonElement;
+      const card = b.closest('.ticket') as HTMLElement | null;
+      const menu = card?.querySelector<HTMLElement>('.ticketMenu');
+      if (!menu) return;
+      const willOpen = menu.hidden;
+      closeAllTicketMenus();
+      menu.hidden = !willOpen;
+      b.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
     });
   });
 
@@ -2343,6 +2435,8 @@ function bindUI(): UIRefs {
     btnCapDrink: must<HTMLButtonElement>('btnCapDrink'),
     btnCapShield: must<HTMLButtonElement>('btnCapShield'),
     ticketList: must('ticketList'),
+    backlogDetails: must<HTMLDetailsElement>('backlogDetails'),
+    backlogSummaryChips: must('backlogSummaryChips'),
     apiLatest: must('apiLatest'),
     apiMin: must('apiMin'),
     oldShare: must('oldShare'),

--- a/src/main.ts
+++ b/src/main.ts
@@ -532,8 +532,14 @@ let tickHandle: number | null = null;
 let uiPending = false;
 let lastTicketsSig = '';
 let lastRegionsSig = '';
+let lastBacklogSummarySig = '';
 let lastTicketsRenderMs = 0;
 let lastRegionsRenderMs = 0;
+
+// Which ticket has its overflow menu open, if any. Persisted across the 1Hz
+// re-renders so the menu doesn't flicker closed when renderTickets rewrites
+// the list via innerHTML.
+let openTicketMenuId: number | null = null;
 
 // Ticket title expand/collapse state (kept across re-renders).
 // Only used for non-architecture tickets (architecture debt titles are always fully visible).
@@ -642,14 +648,28 @@ function toast(msg: string) {
   }, 1100);
 }
 
-function closeAllTicketMenus(except?: HTMLElement) {
+function closeAllTicketMenus() {
+  openTicketMenuId = null;
   refs.ticketList.querySelectorAll<HTMLElement>('.ticketMenu').forEach((m) => {
-    if (m === except) return;
     if (!m.hidden) m.hidden = true;
   });
   refs.ticketList.querySelectorAll<HTMLButtonElement>('button[data-overflow]').forEach((b) => {
     b.setAttribute('aria-expanded', 'false');
   });
+}
+
+// Re-open the menu the user had open before the last innerHTML rewrite.
+function restoreOpenTicketMenu() {
+  if (openTicketMenuId === null) return;
+  const btn = refs.ticketList.querySelector<HTMLButtonElement>(`button[data-overflow="${openTicketMenuId}"]`);
+  const menu = btn?.closest('.ticket')?.querySelector<HTMLElement>('.ticketMenu');
+  if (!btn || !menu) {
+    // Ticket was resolved/removed; clear the memo.
+    openTicketMenuId = null;
+    return;
+  }
+  menu.hidden = false;
+  btn.setAttribute('aria-expanded', 'true');
 }
 
 document.addEventListener('click', (e) => {
@@ -891,7 +911,6 @@ function renderTickets() {
     else if (tk.severity === 1) totals.s1++;
     else totals.s0++;
   }
-  renderBacklogSummary(totals);
 
   // Auto-open the drawer when tickets appear (so tests & players see them),
   // auto-close when the backlog clears — respecting any manual toggle.
@@ -902,9 +921,20 @@ function renderTickets() {
   }
 
   const nowMs = performance.now();
-  // Include UI locale in the signature so a language switch re-renders ticket copy immediately.
   const langSig = getLanguage();
-  const ticketsSig = tickets.map(t => `${t.id}:${t.severity}:${t.impact}:${Math.floor(t.ageSec)}:${t.deferred ? 1 : 0}`).join('|') + `|lang:${langSig}`;
+
+  // Throttle the summary chips: only the counts (+locale) matter, and we do
+  // not want to repaint the canvas HUD every 1Hz tick.
+  const summarySig = `${totals.s3}:${totals.s2}:${totals.s1}:${totals.s0}:${totals.deferred}:${totals.total}|${langSig}`;
+  if (summarySig !== lastBacklogSummarySig) {
+    lastBacklogSummarySig = summarySig;
+    renderBacklogSummary(totals);
+  }
+
+  // Include UI locale in the signature so a language switch re-renders ticket copy immediately.
+  // Age is displayed in whole minutes, so bucket ageSec by minute — otherwise
+  // we'd trash the ticket DOM (and any open overflow menu) every second.
+  const ticketsSig = tickets.map(t => `${t.id}:${t.severity}:${t.impact}:${Math.floor(t.ageSec / 60)}:${t.deferred ? 1 : 0}`).join('|') + `|lang:${langSig}`;
   // Throttle list DOM work even if we tick at 1Hz
   const allow = (nowMs - lastTicketsRenderMs) > 450;
   if (!allow && ticketsSig === lastTicketsSig) return;
@@ -963,6 +993,7 @@ function renderTickets() {
   refs.ticketList.querySelectorAll<HTMLButtonElement>('button[data-defer]').forEach((btn) => {
     btn.addEventListener('click', (e) => {
       const id = Number((e.currentTarget as HTMLElement).getAttribute('data-defer'));
+      openTicketMenuId = null;
       sim.deferTicket(id);
       syncUI();
     });
@@ -970,6 +1001,7 @@ function renderTickets() {
   refs.ticketList.querySelectorAll<HTMLButtonElement>('button[data-open-refactor]').forEach((btn) => {
     btn.addEventListener('click', (e) => {
       const id = Number((e.currentTarget as HTMLElement).getAttribute('data-open-refactor'));
+      openTicketMenuId = null;
       openRefactor(id);
     });
   });
@@ -979,15 +1011,21 @@ function renderTickets() {
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
       const b = e.currentTarget as HTMLButtonElement;
+      const id = Number(b.getAttribute('data-overflow'));
       const card = b.closest('.ticket') as HTMLElement | null;
       const menu = card?.querySelector<HTMLElement>('.ticketMenu');
       if (!menu) return;
       const willOpen = menu.hidden;
       closeAllTicketMenus();
-      menu.hidden = !willOpen;
-      b.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+      if (willOpen) {
+        openTicketMenuId = id;
+        menu.hidden = false;
+        b.setAttribute('aria-expanded', 'true');
+      }
     });
   });
+
+  restoreOpenTicketMenu();
 
   // Title expand/collapse (only shown when the 2-line clamp actually truncates)
   refs.ticketList.querySelectorAll<HTMLButtonElement>('button[data-toggle-title]').forEach((btn) => {

--- a/src/style.css
+++ b/src/style.css
@@ -480,17 +480,143 @@ button, input, select, textarea {
   overflow: hidden;
 }
 
-.canvasHud--backlog #backlogCard {
+.canvasHud--backlog #backlogDetails {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
 }
 
 .canvasHud--backlog .ticketList {
   overflow-y: auto;
   max-height: min(48vh, 420px);
-  padding-right: 4px;
+  padding: 10px 4px 2px 0;
   grid-template-columns: 1fr;
+}
+
+.backlogSummary {
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 4px 2px;
+  outline: none;
+}
+.backlogSummary::-webkit-details-marker { display: none; }
+
+.backlogSummary-k {
+  font-size: var(--type-label-size);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.backlogSummary-chips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.backlogSummary-total {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--md-sys-color-on-surface);
+}
+
+.backlogSummary-chip {
+  font-size: 11px;
+  padding: 0 8px;
+}
+
+.backlogSummary-chip--muted {
+  color: var(--md-sys-color-on-surface-variant);
+  opacity: 0.85;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  background: transparent;
+  padding: 0 8px;
+  border-radius: 999px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.backlogSummary-empty {
+  flex: 1 1 auto;
+}
+
+.backlogSummary-caret {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--md-sys-color-on-surface-variant);
+  transition: transform 160ms ease;
+}
+
+#backlogDetails[open] .backlogSummary-caret {
+  transform: rotate(90deg);
+}
+
+.backlogSummary:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--md-sys-color-primary) 50%, transparent);
+  border-radius: 10px;
+}
+
+/* Ticket meta chip strip + overflow menu */
+.ticketMetaChip {
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  line-height: 1;
+  background: color-mix(in oklab, var(--md-sys-color-surface-container-highest) 70%, transparent);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  color: var(--md-sys-color-on-surface-variant);
+  white-space: nowrap;
+}
+
+.badge.ticketMetaChip {
+  padding: 0 8px;
+}
+
+.ticket {
+  position: relative;
+}
+
+.ticketOverflow {
+  min-width: 36px;
+  padding: 6px 10px;
+  font-size: 18px;
+  line-height: 1;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.ticketMenu {
+  flex: 1 0 100%;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+  padding: 8px;
+  background: color-mix(in oklab, var(--md-sys-color-surface-container-highest) 80%, transparent);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: 12px;
+}
+
+.ticketMenu[hidden] { display: none; }
+
+.ticketMenu .btn {
+  flex: 1 1 auto;
 }
 
 .btn.hud {
@@ -1252,6 +1378,7 @@ select:focus-visible {
 
 .ticket {
   display: flex;
+  flex-wrap: wrap;
   gap: 10px;
   padding: 10px;
   border-radius: 14px;


### PR DESCRIPTION
Backlog HUD now shows a compact severity-chip summary and hides the ticket list behind a `<details>` drawer; auto-opens while tickets exist or during incident heat, stays closed once the user dismisses it. Each ticket card trims to sev badge + title + meta chips + primary Fix action, with Defer and Refactor options tucked into a `⋯` overflow menu.

Primary action row (Start/Pause/Reset/Profile) moves to the bottom of `.sideHeader` so on mobile it sits within thumb reach under the Budget/Rating/Shift/Score strip.

Stacked on top of #97.