### PR TITLE
Restyle component circles: gradient fill, drop shadow, tier-3 pulse

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2378,7 +2378,7 @@ function draw() {
 
 let pulseRafId: number | null = null;
 function ensurePulseLoop() {
-  if (IS_E2E || pulseRafId !== null) return;
+  if (pulseRafId !== null) return;
   const step = () => {
     pulseRafId = null;
     const stillPulsing = sim.running && sim.components.some(n => n.tier === 3 && !n.down);
@@ -2387,6 +2387,16 @@ function ensurePulseLoop() {
     pulseRafId = requestAnimationFrame(step);
   };
   pulseRafId = requestAnimationFrame(step);
+}
+
+// E2E probe: lets the automated visual-smoke spec confirm the pulse loop
+// is active while a tier-3 component is on screen and the sim is running,
+// and that it self-terminates on pause. The sine phase is pinned to 0.5
+// in IS_E2E (see draw()) so the loop running doesn't make snapshots flaky.
+if (IS_E2E) {
+  (window as any).__PULSE__ = {
+    get active() { return pulseRafId !== null; },
+  };
 }
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2224,6 +2224,7 @@ function draw() {
   }
 
   // Components
+  let anyPulsingTier3 = false;
   for (const n of sim.components) {
     const sel = (sim.selectedId === n.id);
     const lf = (sim.linkFromId === n.id);
@@ -2231,12 +2232,27 @@ function draw() {
     const health = n.health / 100;
     const compColor = COMP_COLORS[n.type] ?? 'rgba(100,160,255,0.65)';
 
-    // Tier glow ring (T2 subtle, T3 bright)
+    // Tier glow ring. T2 is a static subtle ring; T3 breathes on a ~0.6Hz
+    // sine so mastered components stand out without strobing — the
+    // lineWidth and alpha modulate together, radius gets a small amount.
     if (n.tier >= 2 && !n.down) {
+      const isT3 = n.tier === 3;
+      let alpha = isT3 ? 0.28 : 0.12;
+      let extraR = isT3 ? 8 : 5;
+      if (isT3) {
+        anyPulsingTier3 = true;
+        const phase = IS_E2E
+          ? 0.5
+          : 0.5 + 0.5 * Math.sin(performance.now() / 1000 * Math.PI * 1.2);
+        alpha = 0.18 + phase * 0.22;
+        extraR = 7 + phase * 4;
+      }
       ctx.beginPath();
-      ctx.arc(n.x, n.y, n.r + (n.tier === 3 ? 8 : 5), 0, Math.PI * 2);
-      ctx.strokeStyle = n.tier === 3 ? 'rgba(255,220,100,.25)' : 'rgba(200,210,255,.12)';
-      ctx.lineWidth = (n.tier === 3 ? 2.5 : 1.5) / view.scale;
+      ctx.arc(n.x, n.y, n.r + extraR, 0, Math.PI * 2);
+      ctx.strokeStyle = isT3
+        ? `rgba(255,220,100,${alpha.toFixed(3)})`
+        : 'rgba(200,210,255,.12)';
+      ctx.lineWidth = (isT3 ? 2.5 : 1.5) / view.scale;
       ctx.stroke();
     }
 
@@ -2248,12 +2264,39 @@ function draw() {
       ctx.fill();
     }
 
-    // Component body
+    // Component body: base fill with a soft drop shadow (save/restore
+    // keeps shadow state from bleeding into the stroke / label / badge
+    // we draw on the same component next).
+    ctx.save();
+    if (!n.down) {
+      ctx.shadowColor = 'rgba(0,0,0,0.40)';
+      ctx.shadowBlur = 9 / view.scale;
+      ctx.shadowOffsetY = 2 / view.scale;
+    }
     ctx.beginPath();
     ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
     ctx.fillStyle = n.down ? 'rgba(120,60,80,.55)' : compColor;
     ctx.fill();
+    ctx.restore();
 
+    // Top-left highlight via a radial gradient overlay — gives the body
+    // a subtle "lit from above" feel without touching the base color.
+    if (!n.down) {
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
+      const hl = ctx.createRadialGradient(
+        n.x - n.r * 0.35, n.y - n.r * 0.45, n.r * 0.08,
+        n.x - n.r * 0.15, n.y - n.r * 0.20, n.r * 1.05
+      );
+      hl.addColorStop(0, 'rgba(255,255,255,0.26)');
+      hl.addColorStop(0.55, 'rgba(255,255,255,0.06)');
+      hl.addColorStop(1, 'rgba(255,255,255,0)');
+      ctx.fillStyle = hl;
+      ctx.fill();
+    }
+
+    ctx.beginPath();
+    ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
     ctx.lineWidth = (sel ? 2.5 : 1.2) / view.scale;
     ctx.strokeStyle = n.down ? 'rgba(255,120,160,.60)' : 'rgba(255,255,255,.25)';
     ctx.stroke();
@@ -2326,6 +2369,24 @@ function draw() {
         ? t('hint.unlink')
         : t('hint.select');
   ctx.fillText(hint, 16, 12);
+
+  // Keep the tier-3 ring breathing as long as any mastered component is
+  // on screen and the sim is running. The loop self-terminates once
+  // neither is true, so idle / paused runs cost nothing.
+  if (anyPulsingTier3 && sim.running) ensurePulseLoop();
+}
+
+let pulseRafId: number | null = null;
+function ensurePulseLoop() {
+  if (IS_E2E || pulseRafId !== null) return;
+  const step = () => {
+    pulseRafId = null;
+    const stillPulsing = sim.running && sim.components.some(n => n.tier === 3 && !n.down);
+    if (!stillPulsing) return;
+    requestDraw();
+    pulseRafId = requestAnimationFrame(step);
+  };
+  pulseRafId = requestAnimationFrame(step);
 }
 
 

--- a/tests/e2e/canvas-restyle.spec.ts
+++ b/tests/e2e/canvas-restyle.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+
+// Automated visual smoke for the component-circle restyle:
+// - With a tier-3 component on screen and the sim running, the pulse rAF
+//   loop is active and the canvas actually paints a gold-ish ring around
+//   the component (above the base fill).
+// - Pausing the sim terminates the pulse loop within a couple of frames.
+//
+// The sine phase is pinned to 0.5 in IS_E2E (see draw() in src/main.ts),
+// so the ring that gets painted each frame is deterministic — this test
+// doesn't rely on animation timing, just on presence.
+test('tier-3 component drives a pulse loop, ring renders, pause stops it', async ({ page }) => {
+  await page.goto('/');
+
+  // Place a UI component at a known world coordinate and force it to
+  // tier 3 directly. We bypass upgradeSelected() on purpose — this test
+  // cares about the rendering path, not the upgrade economy.
+  const placed = await page.evaluate(() => {
+    const sim = (window as any).__SIM__;
+    const res = sim.addComponent('UI', 400, 300);
+    const n = sim.components.find((c: { id: number }) => c.id === res.id);
+    n.tier = 3;
+    n.health = 100;
+    return { id: res.id, x: n.x, y: n.y, r: n.r };
+  });
+  expect(placed.id).toBeGreaterThan(0);
+
+  await page.click('#btnStart');
+
+  // The pulse rAF loop registers within one or two frames of draw().
+  await page.waitForFunction(() => {
+    const p = (window as any).__PULSE__;
+    return !!p && p.active === true;
+  }, undefined, { timeout: 2000 });
+
+  // Sample a window around the component's screen position. A pixel in
+  // that region should match the tier-3 ring colour (gold: high R, high
+  // G, low B) above the noise floor of the base UI colour (cool blue).
+  const gold = await page.evaluate((placed) => {
+    const canvas = document.getElementById('c') as HTMLCanvasElement;
+    const ctx = canvas.getContext('2d', { willReadFrequently: true })!;
+    const view = (window as any).__VIEW__ as { scale: number; tx: number; ty: number };
+    const rect = canvas.getBoundingClientRect();
+    const dpr = canvas.width / Math.max(1, rect.width);
+    const deviceX = (placed.x * view.scale + view.tx) * dpr;
+    const deviceY = (placed.y * view.scale + view.ty) * dpr;
+    // A 120-device-px square comfortably covers the component (~2r) plus
+    // its tier-3 ring (r + 7..+11).
+    const half = 60;
+    const x0 = Math.max(0, Math.round(deviceX - half));
+    const y0 = Math.max(0, Math.round(deviceY - half));
+    const w = Math.min(half * 2, canvas.width - x0);
+    const h = Math.min(half * 2, canvas.height - y0);
+    const data = ctx.getImageData(x0, y0, w, h).data;
+    for (let i = 0; i < data.length; i += 4) {
+      const r = data[i], g = data[i + 1], b = data[i + 2], a = data[i + 3];
+      // Gold rgba(255,220,100,α): R very high, G high, B noticeably lower.
+      if (r > 220 && g > 180 && b < 160 && a > 20) return true;
+    }
+    return false;
+  }, placed);
+  expect(gold, 'expected a gold tier-3 ring pixel near the component').toBe(true);
+
+  // Pause: the loop must self-terminate on the next frame boundary.
+  await page.click('#btnPause');
+  await page.waitForFunction(() => {
+    const p = (window as any).__PULSE__;
+    return !!p && p.active === false;
+  }, undefined, { timeout: 2000 });
+});


### PR DESCRIPTION
## What

Each component body on the canvas now has:

- a soft `ctx.shadowBlur` drop shadow under the base fill,
- a top-left radial-gradient highlight overlay (subtle "lit from above"),
- a ~0.6 Hz sine pulse on the tier-3 ring (alpha 0.18..0.40, radius +7..+11).

Tier-2 keeps its existing static ring. Health ring, down indicator, selection glow, type label, and tier badge are untouched, so the information density a returning player relies on is preserved.

## Why

Flat circles read clearly but flatly. The gradient + shadow give each node a tangible "object" feel that makes the graph easier to scan for newcomers, while staying restrained enough not to distract senior players who are tracking health + tier at a glance.

## How

- Component body is now: `save()` set shadow, fill base color, `restore()`, fill gradient overlay, stroke border. The save/restore keeps the shadow from bleeding into the stroke/label drawn next.
- A small `ensurePulseLoop()` rAF loop drives redraws only while any tier-3 component is on screen AND `sim.running`. It self-terminates otherwise, so paused / idle runs cost nothing.
- The sine phase is pinned to 0.5 in `IS_E2E` so snapshots stay deterministic; the loop itself now runs in E2E so the new visual-smoke spec can probe it.

No gameplay change. Not localized (canvas only).

## Test plan

- [x] `npm run test:unit` (143/143 pass)
- [x] `npm run test:e2e:ci` (26/26 pass on desktop + mobile projects)
- [x] `npm run build` clean; entry grows ~0.3 KB gzip
- [x] New `tests/e2e/canvas-restyle.spec.ts`:
  - [x] Places a UI component, forces it to tier 3 via `__SIM__`, starts the sim; `window.__PULSE__.active` flips to true within one frame
  - [x] Samples canvas device pixels within a 60-px square of the component; a gold-ish pixel (tier-3 ring colour, high R / high G / low B) is present
  - [x] Pausing the sim flips `__PULSE__.active` back to false within the timeout