### PR TITLE
Release v0.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-survival-android",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app-survival-android",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "typescript": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app-survival-android",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.3.4",
   "type": "module",
   "scripts": {
     "dev": "node ./node_modules/vite/bin/vite.js",


### PR DESCRIPTION
Version bump for v0.3.4.

Highlights since v0.3.3:
- Split bundle into lazy chunks (achievements, scoreboard+integrity, challenges+scenarios, per-locale i18n); added FCP-gated prefetch + modulepreload for the user locale. Entry 117 KB raw / 37 KB gzip.
- Compositor-only sticky-header collapse (transform + opacity on scroll, no layout per frame). Mask-image on `.sideBody` replaced with a sticky pseudo-element fade. `backdrop-filter` trimmed to the capacity HUD only. `contain: content` on list rows.
- Event delegation on the ticket list; non-header sparklines gated on the Overview tab being active.
- Canvas component restyle: radial-gradient highlight, soft drop shadow, sine-pulse tier-3 ring.
- New e2e specs: perf invariants (no lazy chunk blocks FCP; locale switch repaints labels; sticky header collapse is compositor-only) and canvas tier-3 pulse smoke.