### PR TITLE
Modernize toolchain, harden CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,37 +1,49 @@
 version: 2
 
 updates:
-  # Node / npm dependencies (root only)
+  # Node / npm dependencies (root only). Devops keeps the toolchain on the
+  # current Q2 2026 line by accepting weekly grouped minor/patch bumps from
+  # CI; security alerts still cut their own PRs ahead of the schedule.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
       time: "02:20"
       timezone: "UTC"
-    open-pull-requests-limit: 0  # disables version-update PRs; security PRs still happen (when alerts exist)
+    open-pull-requests-limit: 5
     labels:
-      - "security"
       - "dependencies"
-    allow:
-      - dependency-type: "production"
+    versioning-strategy: "increase-if-necessary"
     groups:
+      dev-toolchain:
+        applies-to: "version-updates"
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
       npm-security:
         applies-to: "security-updates"
         patterns:
           - "*"
 
-  # GitHub Actions (workflow dependencies)
+  # GitHub Actions (workflow dependencies). All actions are SHA-pinned in the
+  # workflow files; Dependabot rewrites the SHA + trailing version comment in
+  # one PR per group.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
       time: "02:20"
       timezone: "UTC"
-    open-pull-requests-limit: 0  # disables version-update PRs; security PRs still happen (when alerts exist)
+    open-pull-requests-limit: 5
     labels:
-      - "security"
       - "dependencies"
     groups:
+      actions:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
       actions-security:
         applies-to: "security-updates"
         patterns:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,6 +14,8 @@ on:
       - "tests/**"
       - "vitest.config.ts"
       - "playwright.config.ts"
+      - "biome.json"
+      - "tsconfig.json"
       - ".github/workflows/checks.yml"
 
 permissions:
@@ -28,12 +30,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
+      - name: Harden runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
-          # Vite 8 requires Node ^20.19 || >=22.12. Pin to LTS 22 for CI determinism.
-          node-version: 22.16.0
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          # Node 24 is the active LTS as of October 2025; 24.15.0 shipped 2026-04-15.
+          node-version: 24.15.0
           cache: npm
           cache-dependency-path: package-lock.json
 
@@ -53,6 +62,12 @@ jobs:
           NODE_ENV: development
           NPM_CONFIG_PRODUCTION: "false"
         run: npm ci --include=dev --prefer-offline --no-audit --no-fund --progress=false
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
 
       - name: Unit tests
         run: npm run test:unit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL Advanced"
 
 on:
@@ -40,20 +29,10 @@ concurrency:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
-      # required for all workflows
       security-events: write
-
-      # required to fetch internal or private CodeQL packs
       packages: read
-
-      # only required for workflows in private repositories
       actions: read
       contents: read
 
@@ -61,59 +40,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - language: actions
-          build-mode: none
-        - language: javascript-typescript
-          build-mode: none
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Harden runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
 
-    # Add any setup steps before running the `github/codeql-action/init` action.
-    # This includes steps like installing compilers or runtimes (`actions/setup-node`
-    # or others). This is typically only required for manual builds.
-    # - name: Setup runtime (example)
-    #   uses: actions/setup-example@v1
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # Extended query packs surface ~50% more findings than the default
+          # set and add code-quality lints. Both are free for public repos.
+          queries: security-extended,security-and-quality
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,10 +10,15 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  attestations: write
 
 concurrency:
   group: pages
@@ -35,14 +36,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          # Vite 8 requires Node ^20.19 || >=22.12. Pin to LTS 22 for CI determinism.
-          node-version: 22.16.0
+          # Node 24 is the active LTS as of October 2025; 24.15.0 shipped 2026-04-15.
+          node-version: 24.15.0
           cache: npm
           cache-dependency-path: package-lock.json
 
@@ -54,7 +60,7 @@ jobs:
           npm config delete cafile || true
 
       - name: Cache Vite
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             node_modules/.vite
@@ -82,8 +88,13 @@ jobs:
           VITE_COMMIT_SHA: ${{ github.sha }}
         run: npm run build
 
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: 'dist/**/*'
+
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: dist
 
@@ -94,6 +105,11 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/security-nightly.yml
+++ b/.github/workflows/security-nightly.yml
@@ -16,9 +16,11 @@ permissions:
 jobs:
   # NOTE: google/osv-scanner-action provides reusable workflows (not a step-level action).
   # We run it as a separate job and gate downstream logic based on the job result.
+  # Reusable workflows can be pinned by SHA via the `@<sha>` syntax just like
+  # step-level actions; the trailing comment records the human-readable tag.
   osv-scan:
     name: OSV scan
-    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.1"
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@c51854704019a247608d928f370c98740469d4b5" # v2.3.5
     permissions:
       actions: read
       contents: read
@@ -40,13 +42,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22.16.0"
+          # Node 24 is the active LTS as of October 2025; 24.15.0 shipped 2026-04-15.
+          node-version: "24.15.0"
           cache: "npm"
 
       - name: Install
@@ -107,7 +115,7 @@ jobs:
 
       - name: Create/Update PR (only on findings; schedule/dispatch only)
         if: github.event_name != 'pull_request' && steps.gate.outputs.has_findings == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: chore/security-findings
           delete-branch: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Ground rules
 
 Development setup
 
-1. Install Node.js 22 LTS or newer.
+1. Install Node.js 24 LTS or newer.
 2. Install dependencies:
 npm install
 3. Start the dev server:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CodeQL](https://github.com/pzverkov/app-survival-android/actions/workflows/codeql.yml/badge.svg)](https://github.com/pzverkov/app-survival-android/actions/workflows/codeql.yml)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Vite](https://img.shields.io/badge/Vite-8.0-646cff?logo=vite&logoColor=white)](https://vite.dev/)
-[![Node.js](https://img.shields.io/badge/Node.js-22_LTS-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/Node.js-24_LTS-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org/)
 [![Tests](https://img.shields.io/badge/Tests-138_passing-6e9f18?logo=vitest&logoColor=white)](./tests)
 [![Zero Dependencies](https://img.shields.io/badge/Runtime_Deps-0-brightgreen)](./package.json)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue)](./LICENSE)
@@ -48,7 +48,7 @@ The simulation core is written in TypeScript and intentionally kept separate fro
 ## Quick start
 
 Prerequisites
-Node.js 22 LTS or newer is recommended
+Node.js 24 LTS or newer is recommended
 
 Install
 `npm install`

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": ["src/**", "tests/**", "scripts/**", "*.ts", "*.mjs", "*.json"],
+    "ignoreUnknown": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "style": {
+        "noNonNullAssertion": "off",
+        "useTemplate": "warn"
+      },
+      "suspicious": {
+        "noExplicitAny": "warn",
+        "noConsole": "off"
+      },
+      "complexity": {
+        "noForEach": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "all",
+      "arrowParentheses": "always"
+    }
+  },
+  "json": {
+    "formatter": {
+      "indentWidth": 2
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <meta id="themeColor" name="theme-color" content="#0f131c" />
+    <!--
+      Static SPA, so the Content-Security-Policy is shipped as a meta tag.
+      Pass 1 keeps `'unsafe-inline'` for both script-src (Vite injects a
+      build-time locale-preload <script>) and style-src (index.html still
+      uses inline style attributes). Pass 2 will replace the inline preload
+      with an external module and migrate inline styles to CSS classes so
+      both `'unsafe-inline'` allowances can be dropped.
+    -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; manifest-src 'self'; base-uri 'self'; frame-ancestors 'none'; form-action 'none'" />
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>App Survival: Android Release Night</title>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,180 @@
       "name": "app-survival-android",
       "version": "0.3.4",
       "devDependencies": {
-        "@playwright/test": "^1.58.2",
-        "typescript": "^6.0.2",
-        "vite": "^8.0.9",
-        "vitest": "^4.1.2"
+        "@biomejs/biome": "^2.0.0",
+        "@playwright/test": "^1.59.1",
+        "typescript": "^6.0.3",
+        "vite": "^8.0.10",
+        "vitest": "^4.1.5"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.13.tgz",
+      "integrity": "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.13",
+        "@biomejs/cli-darwin-x64": "2.4.13",
+        "@biomejs/cli-linux-arm64": "2.4.13",
+        "@biomejs/cli-linux-arm64-musl": "2.4.13",
+        "@biomejs/cli-linux-x64": "2.4.13",
+        "@biomejs/cli-linux-x64-musl": "2.4.13",
+        "@biomejs/cli-win32-arm64": "2.4.13",
+        "@biomejs/cli-win32-x64": "2.4.13"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.13.tgz",
+      "integrity": "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.13.tgz",
+      "integrity": "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.13.tgz",
+      "integrity": "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.13.tgz",
+      "integrity": "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.13.tgz",
+      "integrity": "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.13.tgz",
+      "integrity": "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.13.tgz",
+      "integrity": "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.13.tgz",
+      "integrity": "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -27,9 +191,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -543,9 +707,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.126.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
-      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -553,13 +717,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -569,9 +733,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -586,9 +750,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -603,9 +767,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -620,9 +784,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -637,9 +801,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
-      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -654,9 +818,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
@@ -671,9 +835,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
@@ -688,9 +852,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
@@ -705,9 +869,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
@@ -722,9 +886,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
-      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
@@ -739,9 +903,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
-      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
@@ -756,9 +920,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
-      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -773,9 +937,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
-      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
       ],
@@ -783,8 +947,8 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
         "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
@@ -792,9 +956,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -809,9 +973,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
-      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -826,9 +990,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
-      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -876,16 +1040,16 @@
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -894,13 +1058,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.2",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -921,9 +1085,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -934,13 +1098,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.2",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -948,14 +1112,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -964,9 +1128,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -974,13 +1138,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.2",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1458,13 +1622,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1477,9 +1641,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1519,14 +1683,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
-      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.126.0",
-        "@rolldown/pluginutils": "1.0.0-rc.16"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -1535,21 +1699,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/siginfo": {
@@ -1636,9 +1800,9 @@
       "optional": true
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1650,16 +1814,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
-      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.16",
+        "rolldown": "1.0.0-rc.17",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -1743,19 +1907,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.2",
-        "@vitest/mocker": "4.1.2",
-        "@vitest/pretty-format": "4.1.2",
-        "@vitest/runner": "4.1.2",
-        "@vitest/snapshot": "4.1.2",
-        "@vitest/spy": "4.1.2",
-        "@vitest/utils": "4.1.2",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -1783,10 +1947,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.2",
-        "@vitest/browser-preview": "4.1.2",
-        "@vitest/browser-webdriverio": "4.1.2",
-        "@vitest/ui": "4.1.2",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -1808,6 +1974,12 @@
           "optional": true
         },
         "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "dev": "node ./node_modules/vite/bin/vite.js",
     "build": "node ./node_modules/typescript/lib/tsc.js -b && node ./node_modules/vite/bin/vite.js build",
     "preview": "node ./node_modules/vite/bin/vite.js preview",
+    "typecheck": "node ./node_modules/typescript/lib/tsc.js -b --noEmit",
+    "lint": "biome lint ./src ./tests ./scripts",
+    "format": "biome format --write ./src ./tests ./scripts",
     "test": "npm run test:unit && npm run build",
     "test:unit": "node ./node_modules/vitest/dist/cli.js run",
     "test:watch": "node ./node_modules/vitest/dist/cli.js",
@@ -16,9 +19,10 @@
     "test:clean": "pkill -f 'app-survival-android/node_modules/vitest' || true"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2",
-    "typescript": "^6.0.2",
-    "vite": "^8.0.9",
-    "vitest": "^4.1.2"
+    "@biomejs/biome": "^2.0.0",
+    "@playwright/test": "^1.59.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.10",
+    "vitest": "^4.1.5"
   }
 }

--- a/src/achievements.ts
+++ b/src/achievements.ts
@@ -1,4 +1,5 @@
-import { EVAL_PRESET, EvalPreset, TicketKind } from './types';
+import { EVAL_PRESET } from './types';
+import type { EvalPreset, TicketKind } from './types';
 import { t } from './i18n';
 
 export type AchievementId = string;
@@ -162,17 +163,18 @@ export function loadPersisted(preset: EvalPreset, storage: AchStorage): AchPersi
   const raw = storage.load(storageKey(preset));
   if (!raw) return defaultPersisted();
   try {
-    const parsed = JSON.parse(raw) as any;
+    const parsed = JSON.parse(raw) as unknown;
     if (!parsed || typeof parsed !== 'object') return defaultPersisted();
+    const obj = parsed as { tiers?: unknown; bestSurvivalSec?: unknown; unlocked?: unknown };
     // New format
-    if (parsed.tiers && typeof parsed.tiers === 'object') {
+    if (obj.tiers && typeof obj.tiers === 'object') {
       return {
-        tiers: { ...(parsed.tiers as Record<string, AchievementTier>) },
-        bestSurvivalSec: Number.isFinite(parsed.bestSurvivalSec) ? parsed.bestSurvivalSec : 0,
+        tiers: { ...(obj.tiers as Record<string, AchievementTier>) },
+        bestSurvivalSec: Number.isFinite(obj.bestSurvivalSec) ? Number(obj.bestSurvivalSec) : 0,
       };
     }
     // Legacy format
-    if (parsed.unlocked && typeof parsed.unlocked === 'object') {
+    if (obj.unlocked && typeof obj.unlocked === 'object') {
       return migrateLegacy(preset, parsed as LegacyPersisted);
     }
     return defaultPersisted();
@@ -524,7 +526,7 @@ export class AchievementsTracker {
         while (next >= 1 && next <= 3) {
           if (!this.shouldUnlockTier(def.id, next as 1 | 2 | 3, ev)) break;
 
-          const tierDef = def.tiers.find(t => t.tier === next) ?? def.tiers[0];
+          const tierDef = def.tiers.find(t => t.tier === next) ?? def.tiers[0]!;
           this.persisted.tiers[def.id] = next;
           unlockedNow.push({
             id: def.id,

--- a/src/actionlog.ts
+++ b/src/actionlog.ts
@@ -64,8 +64,8 @@ export function replayActionLog(input: ReplayInput): ReplayResult {
   let ticks = 0;
   while (ticks < MAX_TICKS) {
     // Apply every action scheduled for this exact tick (in seq order).
-    while (cursor < ordered.length && ordered[cursor].t === sim.timeSec) {
-      applyAction(sim, ordered[cursor]);
+    while (cursor < ordered.length && ordered[cursor]!.t === sim.timeSec) {
+      applyAction(sim, ordered[cursor]!);
       cursor++;
     }
 

--- a/src/challenges.ts
+++ b/src/challenges.ts
@@ -67,7 +67,7 @@ export function getDailyChallenge(): ChallengeDef {
   const m = d.getUTCMonth() + 1;
   const day = d.getUTCDate();
   const idx = (y * 366 + m * 31 + day) % DAILY_TEMPLATES.length;
-  const tmpl = DAILY_TEMPLATES[idx];
+  const tmpl = DAILY_TEMPLATES[idx]!;
   const seed = dateSeed(y, m, day);
 
   return {
@@ -88,7 +88,7 @@ export function getWeeklyChallenge(): ChallengeDef {
   const y = d.getUTCFullYear();
   const wk = weekNumber(d);
   const idx = (y * 53 + wk) % WEEKLY_TEMPLATES.length;
-  const tmpl = WEEKLY_TEMPLATES[idx];
+  const tmpl = WEEKLY_TEMPLATES[idx]!;
   const seed = dateSeed(y, wk, 0);
 
   return {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -363,7 +363,7 @@ export const LOCALES: ReadonlyArray<LocaleMeta> = [
   { id: 'hi', label: 'Hindi', nativeLabel: 'हिन्दी', group: 'more', beta: true },
 ];
 
-const META: Record<Lang, LocaleMeta> = Object.fromEntries(LOCALES.map((l) => [l.id, l])) as any;
+const META: Record<Lang, LocaleMeta> = Object.fromEntries(LOCALES.map((l) => [l.id, l])) as Record<Lang, LocaleMeta>;
 const CANONICAL: Record<string, Lang> = Object.fromEntries(LOCALES.map((l) => [l.id.toLowerCase(), l.id]));
 
 // Vite glob: each per-locale module exports a default Dict. The import() is
@@ -388,8 +388,9 @@ function normalizeLocale(input: string): Lang | null {
   if (lower === 'no' || lower.startsWith('no-')) return 'nb';
 
   // Base language match
-  const base = lower.split('-')[0];
-  if (CANONICAL[base]) return CANONICAL[base];
+  const base = lower.split('-')[0]!;
+  const hit = CANONICAL[base];
+  if (hit) return hit;
 
   // Ukrainian: some environments report 'ua'
   if (base === 'ua') return 'uk';
@@ -534,7 +535,7 @@ export function t(key: string, vars?: Record<string, string | number>): string {
   const enHit = templateFor(key, 'en');
   const tmpl = enHit ?? key;
 
-  const isDev = (import.meta as any)?.env?.DEV === true;
+  const isDev = import.meta.env?.DEV === true;
   if (isDev && tmpl === key) warnMissing(key);
 
   if (!vars) return tmpl;
@@ -543,11 +544,11 @@ export function t(key: string, vars?: Record<string, string | number>): string {
 
 // Dev-only missing key warnings (non-fatal)
 function warnMissing(key: string) {
-  const isDev = (import.meta as any)?.env?.DEV === true;
+  const isDev = import.meta.env?.DEV === true;
   if (!isDev) return;
 
-  (window as any).__i18nMissing = (window as any).__i18nMissing || new Set();
-  const s: Set<string> = (window as any).__i18nMissing;
+  window.__i18nMissing = window.__i18nMissing ?? new Set();
+  const s = window.__i18nMissing;
   if (s.has(key)) return;
   s.add(key);
   // eslint-disable-next-line no-console

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import './style.css';
 import { GameSim } from './sim';
-import { MODE, Mode, ComponentType, Ticket, EvalPreset, EVAL_PRESET, RefactorAction } from './types';
+import { MODE, EVAL_PRESET } from './types';
+import type { Mode, ComponentType, Ticket, EvalPreset, RefactorAction } from './types';
 import './entropy';
 import { Sparkline } from './sparkline';
 import {
@@ -11,8 +12,8 @@ import {
   populateLanguageSelect,
   setLanguage,
   t,
-  type Lang,
 } from './i18n';
+import type { Lang } from './i18n';
 
 import type { AchEvent, AchievementUnlock } from './achievements';
 import type * as ScoreboardModule from './scoreboard';
@@ -261,9 +262,7 @@ type UIRefs = {
 function afterFirstPaint(): Promise<void> {
   return new Promise((resolve) => {
     const schedule = () => {
-      const ric = (window as any).requestIdleCallback as
-        | ((cb: () => void, opts?: { timeout: number }) => number)
-        | undefined;
+      const ric = window.requestIdleCallback;
       if (ric) ric(() => resolve(), { timeout: 500 });
       else setTimeout(() => resolve(), 200);
     };
@@ -338,11 +337,11 @@ function integrityGetTamperState(): { tampered: boolean; reason: string | null }
   return { tampered: false, reason: null };
 }
 function integrityMarkTampered(reason: string): void {
-  if (integrityMod) integrityMod.markTampered(reason as any);
+  if (integrityMod) integrityMod.markTampered(reason);
   else pendingTamperReasons.push(reason);
 }
 function integrityClearTamperIf(reasons: string[]): void {
-  if (integrityMod) integrityMod.clearTamperIf(reasons as any);
+  if (integrityMod) integrityMod.clearTamperIf(reasons);
 }
 function integrityIsScoreSane(score: number, durationSec: number, multiplier: number): boolean {
   if (integrityMod) return integrityMod.isScoreSane(score, durationSec, multiplier);
@@ -367,13 +366,13 @@ const sim = new GameSim();
 
 
 // E2E / CI marker (used by Playwright). Keeps tests deterministic and reduces motion flake.
-const IS_E2E = (import.meta as any).env?.VITE_E2E === '1';
-(window as any).__E2E__ = IS_E2E;
+const IS_E2E = import.meta.env.VITE_E2E === '1';
+window.__E2E__ = IS_E2E;
 if (IS_E2E) document.documentElement.classList.add('e2e');
 
 // E2E test hook: expose the sim so scripted tests can fast-forward deterministically
 // without waiting on the 1 Hz wall-clock tick loop. Never exposed in production.
-if (IS_E2E) (window as any).__SIM__ = sim;
+if (IS_E2E) window.__SIM__ = sim;
 
 const refs = bindUI();
 if (IS_E2E) refs.seedInput.value = '12345';
@@ -437,7 +436,7 @@ function persistRunActionLog(runId: string, seed: number, preset: string, log: R
 Promise.all([integrityModPromise, scoreboardModPromise, integrityKeyPromise]).then(async ([iMod, sbMod, key]) => {
   // Drain any markTampered calls that fired before the integrity chunk
   // landed so the badge state matches the real runtime.
-  for (const r of pendingTamperReasons) iMod.markTampered(r as any);
+  for (const r of pendingTamperReasons) iMod.markTampered(r);
   pendingTamperReasons.length = 0;
 
   if (iMod.needsMigration()) {
@@ -622,7 +621,7 @@ function scrollToTab(id: TabId, _behavior: ScrollBehavior = 'smooth') {
     refs.sideBody.scrollTop = 0;
   };
 
-  const startVT = (document as any).startViewTransition;
+  const startVT = document.startViewTransition;
   if (!IS_E2E && typeof startVT === 'function') {
     startVT.call(document, apply);
   } else {
@@ -699,7 +698,11 @@ let openTicketMenuId: number | null = null;
 const expandedTicketTitles = new Set<number>();
 
 function setText(el: HTMLElement, v: string) { if (el.textContent !== v) el.textContent = v; }
-function setHTML(el: HTMLElement, v: string) { if (el.innerHTML !== v) el.innerHTML = v; } // only called with trusted game-generated strings
+// INVARIANT: setHTML is sim-trusted only. Only ever pass values that are
+// (a) primitive sim state interpolated into a hard-coded template literal, or
+// (b) strings already passed through escapeHtml(). Never thread localStorage,
+// URL params, user input, or untyped values directly into here.
+function setHTML(el: HTMLElement, v: string) { if (el.innerHTML !== v) el.innerHTML = v; }
 
 // Buttons now have an SVG <i class="btn-icon"/> + <span class="btn-label"/>
 // structure. Setting textContent on the button directly would obliterate the
@@ -737,8 +740,8 @@ function trapFocus(e: KeyboardEvent): void {
   const modal = e.currentTarget as HTMLElement;
   const focusable = modal.querySelectorAll<HTMLElement>('button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])');
   if (!focusable.length) return;
-  const first = focusable[0];
-  const last = focusable[focusable.length - 1];
+  const first = focusable[0]!;
+  const last = focusable[focusable.length - 1]!;
   if (e.shiftKey && document.activeElement === first) {
     e.preventDefault();
     last.focus();
@@ -1039,9 +1042,9 @@ function renderTickets() {
   }
 
   // Keep overlay action in sync (incident response quick button)
-  if ((refs as any).incidentOverlayRefill) {
-    (refs as any).incidentOverlayRefill.disabled = !canRefill;
-    setBtnLabel((refs as any).incidentOverlayRefill, t('shop.refillCost', { cost: fmtMoneyUSD(shop.refillCost) }));
+  if (refs.incidentOverlayRefill) {
+    refs.incidentOverlayRefill.disabled = !canRefill;
+    setBtnLabel(refs.incidentOverlayRefill, t('shop.refillCost', { cost: fmtMoneyUSD(shop.refillCost) }));
   }
 
   // Capacity progress bar: live fill width + low/med/high color band.
@@ -1263,7 +1266,7 @@ function startTickLoop() {
 const view = { scale: 1, tx: 0, ty: 0 };
 // Expose the live view transform under E2E so touch tests can convert a
 // component's world position to a viewport tap coordinate.
-if (IS_E2E) (window as any).__VIEW__ = view;
+if (IS_E2E) window.__VIEW__ = view;
 let canvasCssW = 1;
 let canvasCssH = 1;
 let canvasDpr = 1;
@@ -1777,6 +1780,10 @@ refs.btnApplyNextRoadmap.onclick = () => {  const steps = sim.getRefactorRoadmap
     return;
   }
   const next = steps[0];
+  if (!next) {
+    toast(t('toast.noRoadmapTicket'));
+    return;
+  }
   sim.applyRefactor(ticketId, next.action);
   syncUI();
 };
@@ -2084,7 +2091,7 @@ function screenToWorld(e: { clientX: number; clientY: number }) {
 
 function hitComponent(x: number, y: number) {
   for (let i = sim.components.length - 1; i >= 0; i--) {
-    const n = sim.components[i];
+    const n = sim.components[i]!;
     const dx = x - n.x;
     const dy = y - n.y;
     if (dx * dx + dy * dy <= n.r * n.r) return n;
@@ -2394,7 +2401,7 @@ function ensurePulseLoop() {
 // and that it self-terminates on pause. The sine phase is pinned to 0.5
 // in IS_E2E (see draw()) so the loop running doesn't make snapshots flaky.
 if (IS_E2E) {
-  (window as any).__PULSE__ = {
+  window.__PULSE__ = {
     get active() { return pulseRafId !== null; },
   };
 }
@@ -2650,7 +2657,7 @@ function syncUI() {
 
   // ZeroDayPulse
   const adv = sim.getAdvisories().filter(a => !a.mitigated).slice(0, 1);
-  setText(refs.advisoryText, adv.length ? t('advisory.active', { title: adv[0].title }) : '');
+  setText(refs.advisoryText, adv.length ? t('advisory.active', { title: adv[0]!.title }) : '');
 
   // --- Integrity: paused-state tamper check --------------------------------
   if (!sim.running && sim.timeSec > 0) {

--- a/src/oncall.ts
+++ b/src/oncall.ts
@@ -30,7 +30,7 @@ const WINDOW_SEC = 90;
 
 export function tickBurnout(input: BurnoutInput): BurnoutResult {
   const zeroHits = input.zeroHitTimesSec.filter(t => input.timeSec - t < WINDOW_SEC);
-  if (input.capacityCur <= 0 && (zeroHits.length === 0 || input.timeSec - zeroHits[zeroHits.length - 1] >= 5)) {
+  if (input.capacityCur <= 0 && (zeroHits.length === 0 || input.timeSec - zeroHits[zeroHits.length - 1]! >= 5)) {
     zeroHits.push(input.timeSec);
   }
 

--- a/src/rng.ts
+++ b/src/rng.ts
@@ -8,8 +8,10 @@ export class Rng {
 
   /** Returns a float in [0, 1). Deterministic for a given seed + call order. */
   next(): number {
-    // mulberry32
-    let t = (this.state += 0x6D2B79F5);
+    // mulberry32 — keep the state advance and `t` initialisation on separate
+    // lines so the assignment is not embedded inside an expression.
+    this.state = (this.state + 0x6D2B79F5) | 0;
+    let t = this.state;
     t = Math.imul(t ^ (t >>> 15), t | 1);
     t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
     const out = ((t ^ (t >>> 14)) >>> 0) / 4294967296;
@@ -26,7 +28,7 @@ export class Rng {
 
   pick<T>(arr: readonly T[]): T {
     if (!arr.length) throw new Error('Rng.pick: empty array');
-    return arr[this.int(0, arr.length - 1)];
+    return arr[this.int(0, arr.length - 1)]!;
   }
 
   chance(p: number): boolean {

--- a/src/sim.ts
+++ b/src/sim.ts
@@ -21,12 +21,15 @@ const COMPONENT_DEPS: Record<string, Array<'net' | 'image' | 'json' | 'auth' | '
   DEEPLINK: ['json'],
 };
 
-import { ACTION_KEYS, ActionDef, ActionKey, Link, MODE, Mode, Component, ComponentDef, ComponentType, Request, Ticket, TicketKind, TicketSeverity, Advisory, PlatformState, RegionState, RegionCode, EvalPreset, EVAL_PRESET, RunResult, EndReason, ScoreBonus, RefactorOption, RefactorAction, ArchViolation, RefactorRoadmapStep } from './types';
+import { ACTION_KEYS, MODE, EVAL_PRESET } from './types';
+import type { ActionDef, ActionKey, Link, Mode, Component, ComponentDef, ComponentType, Request, Ticket, TicketKind, TicketSeverity, Advisory, PlatformState, RegionState, RegionCode, EvalPreset, RunResult, EndReason, ScoreBonus, RefactorOption, RefactorAction, ArchViolation, RefactorRoadmapStep } from './types';
 import { Rng } from './rng';
 import { entropyPool } from './entropy';
-import { tickPlatformPulse as platformPulseTick, tickCoverageGate as coverageGateTick, computeRegionTarget, evaluateCrossCheck, tickRolloutPhase, applyRegionCoupling, tickBaselineProfile, tickPlayIntegrity, type CoverageGateInput, type CrossCheckInput, type RolloutPhase } from './subsystems';
+import { tickPlatformPulse as platformPulseTick, tickCoverageGate as coverageGateTick, computeRegionTarget, evaluateCrossCheck, tickRolloutPhase, applyRegionCoupling, tickBaselineProfile, tickPlayIntegrity } from './subsystems';
+import type { CoverageGateInput, CrossCheckInput, RolloutPhase } from './subsystems';
 import { tickBurnout } from './oncall';
-import { gradePostmortem, type PostmortemGrade } from './postmortem';
+import { gradePostmortem } from './postmortem';
+import type { PostmortemGrade } from './postmortem';
 import { replayActionLog } from './actionlog';
 
 export const ComponentDefs: Record<ComponentType, ComponentDef> = {
@@ -1032,7 +1035,7 @@ export class GameSim {
   private unlinkViolation(key: string): boolean {
     const [a, b] = key.split('->').map(n => Number(n));
     if (!Number.isFinite(a) || !Number.isFinite(b)) return false;
-    return this.unlink(a, b);
+    return this.unlink(a!, b!);
   }
 
   getRefactorOptions(ticketId: number): RefactorOption[] {
@@ -1421,7 +1424,7 @@ export class GameSim {
     if (this.timeSec > 30 && this.timeSec % 210 === 0) {
       if (this.rand() < 0.28) {
         const deps: Advisory['dep'][] = ['net', 'image', 'json', 'auth', 'analytics'];
-        const dep = deps[this.rng.int(0, deps.length - 1)];
+        const dep = deps[this.rng.int(0, deps.length - 1)]!;
         const sev: TicketSeverity = (this.rand() < 0.35 ? 3 : (this.rand() < 0.65 ? 2 : 1)) as TicketSeverity;
 
         // Determine exposure: if any placed component carries this dep, and we lack mitigations
@@ -2177,7 +2180,7 @@ private tickCoverageGate() {
 
   private computeComponentStats(n: Component) {
     const def = ComponentDefs[n.type];
-    const tierMul = [0, 1.0, 1.35, 1.85][n.tier];
+    const tierMul = [0, 1.0, 1.35, 1.85][n.tier]!;
 
     // Throughput scales strongly with tier, but health/down can crush it.
     n.cap = def.baseCap * tierMul * (n.down ? 0 : (0.35 + (n.health / 100) * 0.65));
@@ -2271,7 +2274,7 @@ private tickCoverageGate() {
     if (outs.length === 0) return [];
 
     if (component.type !== 'REPO') {
-      return [outs[0].id];
+      return [outs[0]!.id];
     }
 
     const cache = outs.find(n => n.type === 'CACHE');
@@ -2309,7 +2312,7 @@ private tickCoverageGate() {
     if (reqType === 'SCROLL' && net && this.rand() < 0.55) targets.push(net.id);
     if (reqType === 'SEARCH' && net && this.rand() < 0.20) targets.push(net.id);
 
-    return targets.length ? targets : [outs[0].id];
+    return targets.length ? targets : [outs[0]!.id];
   }
 
 
@@ -2335,7 +2338,7 @@ private tickCoverageGate() {
     ];
 
     penalties.sort((a, b) => b[1] - a[1]);
-    const top = penalties[0];
+    const top = penalties[0]!;
 
     // If everything is fine, you still get the occasional "love it" review.
     if (top[1] < 0.12) {
@@ -2345,7 +2348,7 @@ private tickCoverageGate() {
         'Works great on my device. Finally.',
         'No crashes, no battery drain - chef’s kiss.'
       ];
-      const snippet = positives[this.rng.int(0, positives.length - 1)];
+      const snippet = positives[this.rng.int(0, positives.length - 1)]!;
       this.recentReviews.unshift(snippet);
       this.recentReviews = this.recentReviews.slice(0, 6);
       this.rating = clamp(this.rating + 0.03, 1.0, 5.0);
@@ -2356,7 +2359,7 @@ private tickCoverageGate() {
 
     const sample = Math.round(30 + (this.timeSec / 30) + this.spawnMul * 15);
     const votes = Math.max(1, Math.round(sample * topVal * 0.6));
-    this.votes[topKey] += votes;
+    this.votes[topKey as keyof typeof this.votes] += votes;
 
     // rating nudge (reviews are noisy, so keep it small per wave)
     this.rating = clamp(this.rating - (0.10 * topVal), 1.0, 5.0);
@@ -2545,7 +2548,7 @@ private tickCoverageGate() {
 
     REGION_OUTAGE: () => {
       const regionIdx = this.rng.int(0, this.regions.length - 1);
-      const region = this.regions[regionIdx];
+      const region = this.regions[regionIdx]!;
       region.frozenSec = Math.max(region.frozenSec, 60);
       region.compliance = clamp(region.compliance - 8, 0, 100);
       this.bumpSupport(6);

--- a/src/subsystems.ts
+++ b/src/subsystems.ts
@@ -68,11 +68,11 @@ export function tickRolloutPhase(input: RolloutInput): { phase: RolloutPhase; pr
   // Promote one step every 60s once qualityProcess clears the bar for that step.
   if (input.timeSec > 0 && input.timeSec % 60 === 0 && phase < 3) {
     const bars = [0.0, 0.25, 0.50];
-    if (input.qualityProcess >= bars[phase]) phase = (phase + 1) as RolloutPhase;
+    if (input.qualityProcess >= bars[phase]!) phase = (phase + 1) as RolloutPhase;
   }
   // Pressure amplifier: closed beta (0) shields the population; 100% (3) fully
   // exposes it. Mid-phases attenuate platform pressure proportionally.
-  const pressureAmplifier = [0.25, 0.5, 0.8, 1.0][phase];
+  const pressureAmplifier = [0.25, 0.5, 0.8, 1.0][phase]!;
   return { phase, pressureAmplifier };
 }
 
@@ -170,7 +170,7 @@ export function tickCoverageGate(input: CoverageGateInput): CoverageGateResult {
     STAFF:      { addTax: 0.70, baseDecay: 0.022, severityW: 1.20 },
     PRINCIPAL:  { addTax: 0.85, baseDecay: 0.026, severityW: 1.35 },
   };
-  const p = PRESETS[input.preset] ?? PRESETS.SENIOR;
+  const p = PRESETS[input.preset] ?? PRESETS.SENIOR!;
 
   if (added > 0) coveragePct = clamp(coveragePct - added * p.addTax, 0, 100);
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="vite/client" />
 
-// Extend Vite ImportMetaEnv with our build-time variables.
-// We also explicitly include common Vite fields so typechecking works even if
-// vite/client types are not resolved in some environments.
+// Extend Vite ImportMetaEnv with our build-time variables. We also explicitly
+// include common Vite fields so typechecking works even if vite/client types
+// are not resolved in some environments.
 interface ImportMetaEnv {
   readonly BASE_URL: string;
   readonly MODE: string;
@@ -11,8 +11,38 @@ interface ImportMetaEnv {
   readonly SSR: boolean;
 
   readonly VITE_COMMIT_SHA?: string;
+  readonly VITE_E2E?: string;
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+// e2e-only: Playwright sets VITE_E2E=1 and the app stamps these globals on
+// `window` so test specs can inspect / drive the simulation directly.
+// `__E2E__` is the deterministic-mode flag, the others are debug surfaces.
+declare global {
+  interface Window {
+    __E2E__?: boolean;
+    __SIM__?: unknown;
+    __VIEW__?: unknown;
+    __PULSE__?: unknown;
+    __i18nMissing?: Set<string>;
+    requestIdleCallback?: (
+      cb: (deadline: { didTimeout: boolean; timeRemaining: () => number }) => void,
+      opts?: { timeout: number }
+    ) => number;
+    cancelIdleCallback?: (handle: number) => void;
+  }
+
+  // View Transitions API — not yet in lib.dom for all TS targets.
+  interface Document {
+    startViewTransition?: (cb: () => void | Promise<void>) => {
+      finished: Promise<void>;
+      ready: Promise<void>;
+      updateCallbackDone: Promise<void>;
+    };
+  }
+}
+
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,12 @@
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "noEmit": true,
 
     "strict": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
-import { defineConfig, type Plugin, type HtmlTagDescriptor } from 'vite';
+import { defineConfig } from 'vite';
+import type { Plugin, HtmlTagDescriptor } from 'vite';
 
 export default defineConfig(() => {
   // For GitHub Pages under a repo path, set VITE_BASE to "/<repo>/" in CI.
@@ -8,7 +9,10 @@ export default defineConfig(() => {
 
   // GH Actions sets VITE_COMMIT_SHA explicitly; Cloudflare Workers Builds
   // exposes WORKERS_CI_COMMIT_SHA; legacy Cloudflare Pages set CF_PAGES_COMMIT_SHA.
-  const commitSha =
+  // We re-export to VITE_COMMIT_SHA via process.env so Vite's built-in
+  // VITE_-prefix substitution handles the replacement (no manual `define`
+  // needed in Vite 8+).
+  process.env.VITE_COMMIT_SHA =
     process.env.VITE_COMMIT_SHA
     ?? process.env.WORKERS_CI_COMMIT_SHA
     ?? process.env.CF_PAGES_COMMIT_SHA
@@ -20,16 +24,17 @@ export default defineConfig(() => {
       prefetchSmallLazyChunks(['integrity', 'meta'], base),
       preloadUserLocale(base),
     ],
-    define: {
-      'import.meta.env.VITE_COMMIT_SHA': JSON.stringify(commitSha),
-    },
     server: {
       port: 5173,
       strictPort: true
     },
+    css: {
+      transformer: 'lightningcss',
+    },
     build: {
       target: 'es2022',
       cssCodeSplit: true,
+      cssMinify: 'lightningcss',
       // Vite's default modulepreload eagerly prefetches every chunk
       // reachable from the entry, which would re-bundle our lazy chunks
       // back onto the first-paint critical path. We hand-pick what to

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,9 @@
 // Production is served from GitHub Pages (see .github/workflows/deploy.yml).
 // The Cloudflare project's "Production branch" is set to a non-existent branch
 // in the dashboard so main never auto-deploys here.
+//
+// This worker only serves static assets (no Node API surface), so we do not
+// enable nodejs_compat — it would broaden runtime API exposure for no gain.
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "app-survival-android",
@@ -12,6 +15,5 @@
   "assets": {
     "directory": "./dist",
     "not_found_handling": "single-page-application"
-  },
-  "compatibility_flags": ["nodejs_compat"]
+  }
 }


### PR DESCRIPTION
Bump Vite/Vitest/TS/Playwright; Node 24.15 LTS in CI. Add Biome 2 lint+format and a typecheck script. Tighten tsconfig (verbatimModuleSyntax, noImplicitOverride, noUncheckedIndexedAccess) and fix the surfaced index errors. SHA-pin all actions, add step-security/harden-runner (audit), enable CodeQL security-extended, attach SLSA build provenance to the Pages artifact, re-enable grouped Dependabot. Drop nodejs_compat from wrangler. 

Add CSP + referrer meta to index.html. Remove window/import.meta as-any casts.