### PR TITLE
Release v0.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app-survival-android",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app-survival-android",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "devDependencies": {
         "@biomejs/biome": "^2.0.0",
         "@playwright/test": "^1.59.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "app-survival-android",
   "private": true,
-  "version": "0.3.5",
+  "version": "0.3.6",
   "type": "module",
   "scripts": {
     "dev": "node ./node_modules/vite/bin/vite.js",


### PR DESCRIPTION
Security and dependency maintenance release.

- vite 8.0.10 -> 8.0.16: resolves the server.fs.deny bypass and launch-editor NTLMv2 alerts, and drops esbuild from the tree (rolldown), clearing the esbuild registry RCE alert
- GitHub Actions: harden-runner v2.19.4, codeql-action v4.36.0, dependency-review-action v5.0.0, osv-scanner-action v2.3.8 (all SHA-pinned)
- Dev toolchain: @biomejs/biome 2.5.0, @playwright/test 1.61.0, vitest 4.1.9
- SECURITY.md: documents the automated scan stack