### PR TITLE
fix dead upward+skip branch in architecture lint

### DIFF
--- a/src/sim.ts
+++ b/src/sim.ts
@@ -882,7 +882,7 @@ export class GameSim {
 
     // Higher layers should depend on lower layers: UI(0)->VM(1)->DOMAIN(2)->REPO(3)->DATA(4)
     const upward = a > b;
-    const skip = (b - a) > 1;
+    const skip = Math.abs(b - a) > 1;
 
     if (!upward && !skip) return { ok: true, debtAdd: 0, reason: 'ok', blocksInPrincipal: false };
 
@@ -964,7 +964,7 @@ export class GameSim {
       const la = layer(a.type);
       const lb = layer(b.type);
       const upward = la > lb;
-      const skip = (lb - la) > 1;
+      const skip = Math.abs(lb - la) > 1;
       if (!upward && !skip) continue;
 
       const kind: 'UPWARD' | 'SKIP' | 'UPWARD_SKIP' = upward && skip ? 'UPWARD_SKIP' : upward ? 'UPWARD' : 'SKIP';
@@ -973,7 +973,7 @@ export class GameSim {
         upward ? `${a.type} → ${b.type} (upward dependency)` :
         `${a.type} → ${b.type} (layer skip)`;
 
-      const severityScore = (upward ? 100 : 0) + (skip ? (lb - la) * 10 : 0);
+      const severityScore = (upward ? 100 : 0) + (skip ? Math.abs(lb - la) * 10 : 0);
       out.push({
         key: `${l.from}->${l.to}`,
         fromId: l.from,

--- a/tests/unit/arch-upward-skip.test.ts
+++ b/tests/unit/arch-upward-skip.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { GameSim } from '../../src/sim';
+
+// A dependency can be both upward (depends on a higher layer) and span more than
+// one layer. Both archLint and getArchViolations must reach the UPWARD_SKIP case;
+// it used to be dead because `skip` was measured in the opposite direction to
+// `upward`, so `upward && skip` was always false.
+describe('architecture lint: upward + layer skip', () => {
+  it('archLint scores an upward dependency that also skips layers as UPWARD_SKIP', () => {
+    const sim: any = new GameSim();
+    sim.reset({ width: 800, height: 600 }, { seed: 1 });
+    // DB (data layer 4) depending on UI (layer 0): upward and spans >1 layer.
+    const res = sim.archLint('DB', 'UI');
+    expect(res.debtAdd).toBe(16); // 10 upward + 6 skip
+    expect(res.reason).toContain('upward + layer skip');
+  });
+
+  it('getArchViolations flags it as UPWARD_SKIP with skip-weighted severity', () => {
+    const sim: any = new GameSim();
+    sim.reset({ width: 800, height: 600 }, { seed: 1 });
+    const db = sim.components.find((c: any) => c.type === 'DB');
+    const ui = sim.components.find((c: any) => c.type === 'UI');
+    sim.link(db.id, ui.id);
+    const v = sim.getArchViolations().find((x: any) => x.fromType === 'DB' && x.toType === 'UI');
+    expect(v).toBeTruthy();
+    expect(v.kind).toBe('UPWARD_SKIP');
+    expect(v.severityScore).toBe(140); // 100 upward + |0-4|*10 skip
+  });
+});


### PR DESCRIPTION
CodeQL flagged three js/useless-comparison-test alerts in src/sim.ts: the skip condition was always false inside upward && skip.

archLint defined upward = a > b but skip = (b - a) > 1, measuring opposite directions, so the two could never both hold. The UPWARD_SKIP kind and the "upward + layer skip" reason were unreachable, and a dependency that went upward across multiple layers was scored as a plain UPWARD (10 debt, not 16). getArchViolations had the same bug, and its severityScore skip term used the signed gap, which would have gone negative for upward links.

Fix: measure the skip distance with Math.abs in both functions and in the severity weight, so the combined case is reachable and scored correctly. Clears all three code-scanning alerts.

Adds tests/unit/arch-upward-skip.test.ts covering the UPWARD_SKIP debt (16) and severity (140).